### PR TITLE
Initial version of EosioRpcProviderProtocol.

### DIFF
--- a/EosioSwift.xcodeproj/project.pbxproj
+++ b/EosioSwift.xcodeproj/project.pbxproj
@@ -18,6 +18,14 @@
 		6B80D26921FA6DDF00716A7B /* EosioSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B80D25F21FA6DDF00716A7B /* EosioSwift.framework */; };
 		6B80D26E21FA6DDF00716A7B /* EosioSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80D26D21FA6DDF00716A7B /* EosioSwiftTests.swift */; };
 		6B80D27021FA6DDF00716A7B /* EosioSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B80D26221FA6DDF00716A7B /* EosioSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B4892C67221E02960050FA72 /* BlankModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4892C66221E02960050FA72 /* BlankModels.swift */; };
+		B4892C6D221E0CAA0050FA72 /* RequestModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4892C6C221E0CAA0050FA72 /* RequestModels.swift */; };
+		B49EE50F221CC78900018D29 /* EosioHttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE50E221CC78900018D29 /* EosioHttpMethod.swift */; };
+		B49EE511221CC7E900018D29 /* EosioResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE510221CC7E900018D29 /* EosioResult.swift */; };
+		B49EE513221CC8AC00018D29 /* EosioRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE512221CC8AC00018D29 /* EosioRequest.swift */; };
+		B49EE515221CC90100018D29 /* EosioResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE514221CC90100018D29 /* EosioResponse.swift */; };
+		B49EE517221CC94F00018D29 /* EosioEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE516221CC94F00018D29 /* EosioEndpoint.swift */; };
+		B49EE519221CCA0900018D29 /* RpcProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EE518221CCA0900018D29 /* RpcProviderProtocol.swift */; };
 		B4B69EBF2204B65E009260A5 /* SignatureProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B69EBE2204B65E009260A5 /* SignatureProviderProtocol.swift */; };
 		D5BFB1230A59BB8A0FA38330 /* Pods_EosioSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC90074E5682E66407277928 /* Pods_EosioSwift.framework */; };
 /* End PBXBuildFile section */
@@ -51,6 +59,14 @@
 		6B80D26D21FA6DDF00716A7B /* EosioSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioSwiftTests.swift; sourceTree = "<group>"; };
 		6B80D26F21FA6DDF00716A7B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F9FACA18719237291A2B3C4 /* Pods_EosioSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EosioSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4892C66221E02960050FA72 /* BlankModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankModels.swift; sourceTree = "<group>"; };
+		B4892C6C221E0CAA0050FA72 /* RequestModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestModels.swift; sourceTree = "<group>"; };
+		B49EE50E221CC78900018D29 /* EosioHttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioHttpMethod.swift; sourceTree = "<group>"; };
+		B49EE510221CC7E900018D29 /* EosioResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioResult.swift; sourceTree = "<group>"; };
+		B49EE512221CC8AC00018D29 /* EosioRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioRequest.swift; sourceTree = "<group>"; };
+		B49EE514221CC90100018D29 /* EosioResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioResponse.swift; sourceTree = "<group>"; };
+		B49EE516221CC94F00018D29 /* EosioEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioEndpoint.swift; sourceTree = "<group>"; };
+		B49EE518221CCA0900018D29 /* RpcProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpcProviderProtocol.swift; sourceTree = "<group>"; };
 		B4B69EBE2204B65E009260A5 /* SignatureProviderProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignatureProviderProtocol.swift; sourceTree = "<group>"; };
 		EC90074E5682E66407277928 /* Pods_EosioSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EosioSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -108,6 +124,7 @@
 		6B80D26121FA6DDF00716A7B /* EosioSwift */ = {
 			isa = PBXGroup;
 			children = (
+				B49EE50D221CC63700018D29 /* EosioRpcProviderProtocol */,
 				B4B69EBD2204B631009260A5 /* EosioSignatureProviderProtocol */,
 				6B80D26221FA6DDF00716A7B /* EosioSwift.h */,
 				28FE03972209D44700CCC977 /* EosioTransaction.swift */,
@@ -140,6 +157,29 @@
 				4E6D3803DC54D1874518F969 /* Pods-EosioSwiftTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		B4892BF9221DC3AA0050FA72 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B4892C66221E02960050FA72 /* BlankModels.swift */,
+				B4892C6C221E0CAA0050FA72 /* RequestModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		B49EE50D221CC63700018D29 /* EosioRpcProviderProtocol */ = {
+			isa = PBXGroup;
+			children = (
+				B4892BF9221DC3AA0050FA72 /* Models */,
+				B49EE50E221CC78900018D29 /* EosioHttpMethod.swift */,
+				B49EE510221CC7E900018D29 /* EosioResult.swift */,
+				B49EE512221CC8AC00018D29 /* EosioRequest.swift */,
+				B49EE514221CC90100018D29 /* EosioResponse.swift */,
+				B49EE516221CC94F00018D29 /* EosioEndpoint.swift */,
+				B49EE518221CCA0900018D29 /* RpcProviderProtocol.swift */,
+			);
+			path = EosioRpcProviderProtocol;
 			sourceTree = "<group>";
 		};
 		B4B69EBD2204B631009260A5 /* EosioSignatureProviderProtocol */ = {
@@ -337,8 +377,16 @@
 			files = (
 				28D8C7A22215D016000F1DC2 /* SerializedEosioTransaction.swift in Sources */,
 				2856028F22182EFA00642377 /* EosioTransactionAbis.swift in Sources */,
+				B49EE50F221CC78900018D29 /* EosioHttpMethod.swift in Sources */,
+				B49EE515221CC90100018D29 /* EosioResponse.swift in Sources */,
+				B4892C67221E02960050FA72 /* BlankModels.swift in Sources */,
 				28FE03982209D44700CCC977 /* EosioTransaction.swift in Sources */,
+				B4892C6D221E0CAA0050FA72 /* RequestModels.swift in Sources */,
 				28FE039A2209D4C100CCC977 /* EosioTransactionAction.swift in Sources */,
+				B49EE519221CCA0900018D29 /* RpcProviderProtocol.swift in Sources */,
+				B49EE513221CC8AC00018D29 /* EosioRequest.swift in Sources */,
+				B49EE511221CC7E900018D29 /* EosioResult.swift in Sources */,
+				B49EE517221CC94F00018D29 /* EosioEndpoint.swift in Sources */,
 				B4B69EBF2204B65E009260A5 /* SignatureProviderProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EosioSwift/EosioRpcProviderProtocol/EosioEndpoint.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/EosioEndpoint.swift
@@ -1,0 +1,25 @@
+//
+//  EosioEndpoint.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+
+public class EosioEndpoint {
+    private(set) var endPoint: String
+    private(set) var configuration: URLSessionConfiguration = URLSessionConfiguration.default
+    
+    public var baseUrl: URL? {
+        return URL(string: endPoint)
+    }
+    
+    init?(_ endPoint: String, configuration: URLSessionConfiguration = URLSessionConfiguration.default)  {
+        self.endPoint = endPoint
+        self.configuration = configuration
+        guard let _ = URL(string: endPoint) else { return nil }
+    }
+}
+

--- a/EosioSwift/EosioRpcProviderProtocol/EosioHttpMethod.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/EosioHttpMethod.swift
@@ -1,0 +1,21 @@
+//
+//  EosioHttpMethod.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+
+public enum EosioHttpMethod: String {
+    case get = "GET"
+    case put = "PUT"
+    case post = "POST"
+    case delete = "DELETE"
+    case head = "HEAD"
+    case options = "OPTIONS"
+    case trace = "TRACE"
+    case connect = "CONNECT"
+    case patch = "PATCH"
+}

--- a/EosioSwift/EosioRpcProviderProtocol/EosioRequest.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/EosioRequest.swift
@@ -1,0 +1,24 @@
+//
+//  EosioRequest.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+
+public class EosioRequest {
+    public var function: String
+    public var method: EosioHttpMethod
+    public var parameters: Codable?
+    public var headers: [String:String]?
+    
+    init(function: String, parameters: Codable? = nil, method: EosioHttpMethod = EosioHttpMethod.post,
+         headers: [String:String]? = ["Content-Type":"application/json; charset=utf-8"]) {
+        self.function = function
+        self.method = method
+        self.parameters = parameters
+        self.headers = headers
+    }
+}

--- a/EosioSwift/EosioRpcProviderProtocol/EosioResponse.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/EosioResponse.swift
@@ -1,0 +1,47 @@
+//
+//  EosioResponse.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+import EosioSwiftFoundation
+
+public class EosioResponse {
+    public var data: Data?
+    public var statusCode: Int
+    public var httpResponse: HTTPURLResponse?
+    
+    var string: String? {
+        guard let data = data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+    
+    init(data: Data? = nil, statusCode: Int = 0, httpResponse: HTTPURLResponse? = nil) {
+        self.data = data
+        self.statusCode = statusCode
+        self.httpResponse = httpResponse
+    }
+    
+    func decodeJson<T:Decodable>() -> EosioResult<T> {
+        guard let data = data else {
+            return EosioResult.empty
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        if let json = string {
+            let jsonKey = CodingUserInfoKey(rawValue: "json")!
+            decoder.userInfo[jsonKey] = json
+        }
+        
+        do {
+            let rpcResponse = try decoder.decode(T.self, from: data)
+            return EosioResult.success(rpcResponse)
+        }
+        catch {
+            return EosioResult.error(EosioError(EosioErrorCode.parsingError, reason: error.localizedDescription))
+        }
+    }
+}

--- a/EosioSwift/EosioRpcProviderProtocol/EosioResult.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/EosioResult.swift
@@ -1,0 +1,16 @@
+//
+//  EosioResult.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+import EosioSwiftFoundation
+
+public enum EosioResult<T> {
+    case success(T)
+    case error(EosioError)
+    case empty
+}

--- a/EosioSwift/EosioRpcProviderProtocol/Models/BlankModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/Models/BlankModels.swift
@@ -1,0 +1,75 @@
+//
+//  BlankModels.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/20/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+
+public struct EosioRpcInfo: Codable {
+    
+}
+
+public struct EosioRpcBlock: Codable {
+    
+}
+
+public struct EosioRpcBlockHeaderState: Codable {
+    
+}
+
+public struct EosioRpcAccount: Codable {
+    
+}
+
+public struct EosioRpcAccountAbi: Codable {
+    
+}
+
+public struct EosioRpcRawAbi: Codable {
+    
+}
+
+public struct EosioRpcRawCodeAbi: Codable {
+    
+}
+
+public struct EosioRpcTableRows: Codable {
+    
+}
+
+public struct EosioRpcCurrencyBalance: Codable {
+    
+}
+
+public struct EosioRpcRequiredKeys: Codable {
+    
+}
+
+public struct EosioRpcCurrencyStats: Codable {
+    
+}
+
+public struct EosioRpcProducers: Codable {
+    
+}
+
+public struct EosioRpcTransaction: Codable {
+    
+}
+
+public struct EosioRpcHistoryActions: Codable {
+    
+}
+
+public struct EosioRpcKeyAccounts: Codable {
+    
+}
+
+public struct EosioRpcControllingAccounts: Codable {
+    
+}
+
+

--- a/EosioSwift/EosioRpcProviderProtocol/Models/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/Models/RequestModels.swift
@@ -1,0 +1,73 @@
+//
+//  RequestModels.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/20/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+import EosioSwiftFoundation
+
+public struct EosioRpcTableRowsRequest: Codable {
+    var scope: String = "inita"
+    var code: String = "currency"
+    var table: String = "account"
+    var tableKey: String?
+    var json : Bool
+    var lowerBound : String?
+    var upperBound: String?
+    var limit : Int = 10
+    var indexPosition : String = "1"
+    var keyType: String?
+    var encodeType : String = "dec"
+    
+    enum CodingKeys: String, CodingKey {
+        case scope
+        case code
+        case table
+        case tableKey = "table_key"
+        case json
+        case lowerBound = "lower_bound"
+        case upperBound = "upper_bound"
+        case limit
+        case indexPosition = "index_position"
+        case keyType = "key_type"
+        case encodeType = "encode_type"
+    }
+}
+
+public struct EosioRpcCurrencyBalanceRequest: Codable {
+    var code: String
+    var account: String
+    var symbol: String
+}
+
+public struct EosioRpcRequiredKeysRequest: Codable {
+    var transactionJson: String
+    var availableKeys: [String]
+    
+    enum CodingKeys: String, CodingKey {
+        case transactionJson = "transaction"
+        case availableKeys = "available_keys"
+    }
+}
+
+public struct EosioRpcProducersRequest: Codable {
+    var limit: String
+    var lowerBound: String
+    var json: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case limit
+        case lowerBound = "lower_bound"
+        case json
+    }
+}
+
+public struct EosioRpcHistoryActionsRequest: Codable {
+    var position: Int32 = -1
+    var offset: Int32 = -20
+    var accountName: EosioName
+}
+

--- a/EosioSwift/EosioRpcProviderProtocol/RpcProviderProtocol.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RpcProviderProtocol.swift
@@ -1,0 +1,73 @@
+//
+//  RpcProviderProtocol.swift
+//  EosioSwift
+//
+//  Created by Steve McCoole on 2/19/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+import EosioSwiftFoundation
+
+public protocol RpcProviderProtocol {
+    
+    var endpoints: [EosioEndpoint] { get }
+    var failoverRetries: Int { get }
+    var primaryEndpoint: EosioEndpoint { get }
+    
+    init(endpoints: [EosioEndpoint], failoverRetries: Int)
+    
+    func rpcRequest(request: EosioRequest, completion: @escaping (EosioResult<EosioResponse>)->Void)
+    
+    /** Calls /v1/chain/get_info */
+    func getInfo(completion: @escaping(EosioResult<EosioRpcInfo>) -> Void)
+    
+    /** Calls `/v1/chain/get_block` */
+    func getBlock(blockNum: UInt64, completion: @escaping(EosioResult<EosioRpcBlock>) -> Void)
+    
+    /** Calls `/v1/chain/get_block_header_state` */
+    func getBlockHeaderState(blockNum: UInt64, completion: @escaping(EosioResult<EosioRpcBlockHeaderState>) -> Void)
+    
+    /** Calls `/v1/chain/get_block_header_state` */
+    func getBlockHeaderState(blockId: String, completion: @escaping(EosioResult<EosioRpcBlockHeaderState>) -> Void)
+    
+    /** Calls `/v1/chain/get_account` */
+    func getAccount(account: EosioName, completion: @escaping(EosioResult<EosioRpcAccount>) -> Void)
+    
+    /** Calls `/v1/chain/get_raw_abi` */
+    func getRawAbi(account: EosioName, completion: @escaping(EosioResult<EosioRpcRawAbi>) -> Void)
+    
+    /** Calls `/v1/chain/get_raw_code_and_abi` */
+    func getRawCodeAndAbi(account: EosioName, completion: @escaping(EosioResult<EosioRpcRawCodeAbi>) -> Void)
+    
+    /** Calls `/v1/chain/get_table_rows` */
+    func getTableRows(parameters: EosioRpcTableRowsRequest, completion: @escaping(EosioResult<EosioRpcTableRows>) -> Void)
+    
+    /** Calls `/v1/chain/get_required_keys` */
+    func getRequiredKeys(parameters: EosioRpcRequiredKeysRequest, completion: @escaping(EosioResult<EosioRpcRequiredKeys>) -> Void)
+    
+    /** Calls `/v1/chain/get_currency_stats` */
+    func getCurrencyStats(code: String, symbol: String, completion: @escaping(EosioResult<EosioRpcCurrencyStats>) -> Void)
+    
+    /** Calls `/v1/chain/get_producers` */
+    func getProducers(parameters: EosioRpcProducersRequest, completion: @escaping(EosioResult<EosioRpcProducers>) -> Void)
+    
+    /** Calls `/v1/chain/push_transaction` */
+    func pushTransaction(transaction: EosioTransaction, completion: @escaping(EosioResult<EosioRpcTransaction>) -> Void)
+    
+    /** Calls `/v1/chain/push_transaction` */
+    func pushTransactions(transactions: [EosioTransaction], completion: @escaping ([EosioResult<EosioRpcTransaction>]) -> Void)
+    
+    /** Calls `/v1/history/get_actions` */
+    func getHistoryActions(parameters: EosioRpcHistoryActionsRequest, completion: @escaping(EosioResult<EosioRpcHistoryActions>) -> Void)
+    
+    /** Calls `/v1/history/get_transaction` */
+    func getHistoryTransaction(transactionId: String, completion: @escaping(EosioResult<EosioRpcTransaction>) -> Void)
+    
+    /** Calls `/v1/history/get_key_accounts` */
+    func getHistoryKeyAccounts(publicKey: String, completion: @escaping (EosioResult<EosioRpcKeyAccounts>) -> Void)
+    
+    /** Calls `/v1/history/get_controlled_accounts` */
+    func getHistoryControlledAccounts(controllingAccount: EosioName, completion: @escaping (EosioResult<EosioRpcControllingAccounts>) -> Void)
+    
+}


### PR DESCRIPTION
Includes supporting classes and structs.  Response objects are currently
blank implementation stubs until we can get model generation sorted out.
Request objects had already been hand written so they were included but
they can be replaced when we can generate them from schema as well.