### PR TITLE
Separated DateFormatter() boilerplate code into its own extension

### DIFF
--- a/EosioSwift.xcodeproj/project.pbxproj
+++ b/EosioSwift.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		B4E8F6BE22320AC700FA7E63 /* Base58String.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E8F6BD22320AC700FA7E63 /* Base58String.swift */; };
 		B4E8F6C022320E3F00FA7E63 /* Base58Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E8F6BF22320E3F00FA7E63 /* Base58Tests.swift */; };
 		B4E8F6C222320EB700FA7E63 /* RIPEMD160Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E8F6C122320EB700FA7E63 /* RIPEMD160Tests.swift */; };
+		BBAC7BCE225266A40035CDBC /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAC7BCD225266A40035CDBC /* DateExtensionTests.swift */; };
 		BBCA8F422241331C00B02372 /* EosioTransactionActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCA8F412241331C00B02372 /* EosioTransactionActionTests.swift */; };
 		D9EC085EBBCF1FFF1D2D012C /* Pods_EosioSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5835070C5F7998E17BF06017 /* Pods_EosioSwiftTests.framework */; };
 /* End PBXBuildFile section */
@@ -120,6 +121,7 @@
 		B4E8F6BD22320AC700FA7E63 /* Base58String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base58String.swift; sourceTree = "<group>"; };
 		B4E8F6BF22320E3F00FA7E63 /* Base58Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base58Tests.swift; sourceTree = "<group>"; };
 		B4E8F6C122320EB700FA7E63 /* RIPEMD160Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RIPEMD160Tests.swift; sourceTree = "<group>"; };
+		BBAC7BCD225266A40035CDBC /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		BBCA8F412241331C00B02372 /* EosioTransactionActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioTransactionActionTests.swift; sourceTree = "<group>"; };
 		D3E4478EE834B70DDF06A7FA /* Pods_EosioSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EosioSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7404A6D5764E579E57E1897 /* Pods-EosioSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EosioSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-EosioSwiftTests/Pods-EosioSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 				8F77127C2232FD6D004256D3 /* EosioTransactionTests.swift */,
 				BBCA8F412241331C00B02372 /* EosioTransactionActionTests.swift */,
 				28DDAB092237030E008FB1CC /* EosioKeySignatureExtensionTests.swift */,
+				BBAC7BCD225266A40035CDBC /* DateExtensionTests.swift */,
 			);
 			path = EosioSwiftTests;
 			sourceTree = "<group>";
@@ -561,6 +564,7 @@
 			files = (
 				8F6B04CE22287B1D00215CD0 /* StringExtensionsTests.swift in Sources */,
 				B4A80E2D221F605D00C5134D /* EosioMockRpcProviderTests.swift in Sources */,
+				BBAC7BCE225266A40035CDBC /* DateExtensionTests.swift in Sources */,
 				8F77127D2232FD6D004256D3 /* EosioTransactionTests.swift in Sources */,
 				B4E8F6C222320EB700FA7E63 /* RIPEMD160Tests.swift in Sources */,
 				8F6B04CF22287B1D00215CD0 /* DataExtensionsTests.swift in Sources */,

--- a/EosioSwift/EosioRpcProviderImpl/EosioRpcRouter.swift
+++ b/EosioSwift/EosioRpcProviderImpl/EosioRpcRouter.swift
@@ -84,11 +84,7 @@ public enum EosioRpcRouter : EosioRequestConvertible {
         var urlRequest: URLRequest?
         var parameters: Data?
         let encoder = JSONEncoder()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        encoder.dateEncodingStrategy = .formatted(formatter)
+        encoder.dateEncodingStrategy = .formatted(Date.asTransactionTimeStamp)
         encoder.keyEncodingStrategy = .convertToSnakeCase
         
         // Handle getting the proper parameters and endpoint (only the 5 that we use are implemented for now)

--- a/EosioSwift/Extensions/DateExtensions.swift
+++ b/EosioSwift/Extensions/DateExtensions.swift
@@ -29,7 +29,7 @@ public extension Date {
             - yyyyMMddTHHmmss: The timestamp string.
         - Returns: A `Date` object or `nil` if the timestamp string can't be converted to `Date`.
     */
-    public init?(yyyyMMddTHHmmss: String?) {
+    init?(yyyyMMddTHHmmss: String?) {
         guard let yyyyMMddTHHmmss = yyyyMMddTHHmmss else { return nil }
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
@@ -45,13 +45,24 @@ public extension Date {
     /**
         Returns a string representation of the `Date` object.
     */
-    public var yyyyMMddTHHmmss: String {
+    var yyyyMMddTHHmmss: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter.string(from: self)
     }
+
+    /**
+     Returns a DateFormatter instance customized for `JSONEncoder.dateEncodingStrategy`
+     */
+    static let asTransactionTimeStamp: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
     
 }
 

--- a/EosioSwift/Extensions/EncodableExtensions.swift
+++ b/EosioSwift/Extensions/EncodableExtensions.swift
@@ -45,11 +45,7 @@ public extension Encodable {
         if convertToSnakeCase {
             jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
         }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        jsonEncoder.dateEncodingStrategy = .formatted(formatter)
+        jsonEncoder.dateEncodingStrategy = .formatted(Date.asTransactionTimeStamp)
         return try jsonEncoder.encode(self)
     }
     

--- a/EosioSwiftTests/DateExtensionTests.swift
+++ b/EosioSwiftTests/DateExtensionTests.swift
@@ -1,0 +1,29 @@
+//
+//  DateExtensionTests.swift
+//  EosioSwiftTests
+//
+//  Created by Serguei Vinnitskii on 4/1/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import XCTest
+import EosioSwift
+
+class DateExtensionTests: XCTestCase {
+
+    func test_formattedForJSONEncoder() {
+
+        // create a date in required format
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+
+        // create a date with extension
+        let dateFormatterForJSONEncoder = Date.asTransactionTimeStamp
+
+        // compare
+        XCTAssertTrue(formatter.dateFormat == dateFormatterForJSONEncoder.dateFormat)
+    }
+
+}


### PR DESCRIPTION
- Replaced boilerplate code for DateFormatter() with using new extension in 2 places in codebase.
- Added Unit Test.
- Fixed warnings.