### PR TITLE
2 example tests showing how OHHTTPStubs works for testing.

### DIFF
--- a/EosioSwift.xcodeproj/project.pbxproj
+++ b/EosioSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F9DCB702255A3FD00853105 /* EosioRpcProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9DCB6F2255A3FD00853105 /* EosioRpcProviderTests.swift */; };
 		284C5E682224558800795392 /* EosioAbiProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284C5E672224558800795392 /* EosioAbiProviderTests.swift */; };
 		2856028F22182EFA00642377 /* EosioTransactionAbis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2856028E22182EFA00642377 /* EosioTransactionAbis.swift */; };
 		28A7A3B722236641002386D3 /* EosioAbiProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A7A3B622236641002386D3 /* EosioAbiProviderProtocol.swift */; };
@@ -68,6 +69,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F9DCB6F2255A3FD00853105 /* EosioRpcProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EosioRpcProviderTests.swift; sourceTree = "<group>"; };
 		284C5E672224558800795392 /* EosioAbiProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioAbiProviderTests.swift; sourceTree = "<group>"; };
 		2856028E22182EFA00642377 /* EosioTransactionAbis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioTransactionAbis.swift; sourceTree = "<group>"; };
 		28A7A3B622236641002386D3 /* EosioAbiProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioAbiProviderProtocol.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 		6B80D26C21FA6DDF00716A7B /* EosioSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
+				1F9DCB6F2255A3FD00853105 /* EosioRpcProviderTests.swift */,
 				8F6B04CA22287B1D00215CD0 /* DataExtensionsTests.swift */,
 				8F6B04C722287B1D00215CD0 /* EncodableExtensionTests.swift */,
 				8F6B04CB22287B1D00215CD0 /* EosioNameTests.swift */,
@@ -562,6 +565,7 @@
 				B4A80E2D221F605D00C5134D /* EosioMockRpcProviderTests.swift in Sources */,
 				BBAC7BCE225266A40035CDBC /* DateExtensionTests.swift in Sources */,
 				8F77127D2232FD6D004256D3 /* EosioTransactionTests.swift in Sources */,
+				1F9DCB702255A3FD00853105 /* EosioRpcProviderTests.swift in Sources */,
 				B4E8F6C222320EB700FA7E63 /* RIPEMD160Tests.swift in Sources */,
 				8F6B04CF22287B1D00215CD0 /* DataExtensionsTests.swift in Sources */,
 				8F6B04D022287B1D00215CD0 /* EosioNameTests.swift in Sources */,

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -1,0 +1,122 @@
+//
+//  EosioRpcProviderTests.swift
+//  EosioSwiftTests
+//
+//  Created by Ben Martell on 4/3/19.
+//  Copyright © 2019 block.one. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import EosioSwift
+import OHHTTPStubs
+
+class EosioRpcProviderTests: XCTestCase {
+
+    var rpcProvider: EosioRpcProviderProtocol? = nil
+    
+    override func setUp() {
+        super.setUp()
+        let url = URL(string: "https://api.testnet.dev.b1ops.net")
+        rpcProvider = EosioRpcProvider(endpoint: url!)
+        
+        // display stub intercept occurance during testing.
+        OHHTTPStubs.onStubActivation { (request, stub, rsponse) in
+            print("\(request.url!) stubbed by \(stub.name!).")
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        
+        // This needs to always happen: remove all stubs on tear down
+        OHHTTPStubs.removeAllStubs()
+    }
+    
+    func testGetBlock() {
+        
+        //This is a simple example of how a stub intercept works. This is the "happy path" example. Not that this NOT ONLY provides a response but is also validating the URL being called is actually correct (see the OHHTTPStubsTestBlock matchers in the OHHTTPStubs documentation at: https://github.com/AliSoftware/OHHTTPStubs/blob/master/README.md or simpley control click on isAbsoluteURLString and  jump to definiction below to see that and other matchers that are available.
+        
+        (stub(condition: isAbsoluteURLString("https://api.testnet.dev.b1ops.net/v1/chain/get_block")) { _ in
+            
+            //here we set the response to the request along with the HTTP staus code desired.
+            let json = self.createBlockResponseJson()
+            let data = json.data(using: .utf8)
+            return OHHTTPStubsResponse(data: data!, statusCode: 200, headers: nil)
+        }).name = "Get Block stub"
+        
+        // Rest of standard testing stuff.
+        let expect = expectation(description: "testGetBlock")
+        
+        let requestParameters = EosioRpcBlockRequest(block_num_or_id: 25260032)
+        rpcProvider?.getBlock(requestParameters: requestParameters) { response in
+            switch response {
+            case .success(let infoResponse):
+                XCTAssertTrue(infoResponse.blockNum == 25260032)
+                XCTAssertTrue(infoResponse.refBlockPrefix == 2249927103)
+                XCTAssertTrue(infoResponse.id == "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+            case .failure(let err):
+                print(err.description)
+                XCTFail()
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 30)
+    }
+    
+    func testGetBlockServerError() {
+        
+        (stub(condition: isAbsoluteURLString("https://api.testnet.dev.b1ops.net/v1/chain/get_block")) { _ in
+            
+            //here we set the response to the request along with the HTTP staus code desired.
+            let error = NSError(domain:NSURLErrorDomain, code:500, userInfo:nil)
+            return OHHTTPStubsResponse(error:error)
+        }).name = "Get Block Error stub"
+        
+        let expect = expectation(description: "testGetBlockError")
+        
+        let requestParameters = EosioRpcBlockRequest(block_num_or_id: 25260032)
+        rpcProvider?.getBlock(requestParameters: requestParameters) { response in
+            switch response {
+            case .success( _):
+               XCTFail()
+            case .failure(let err):
+                XCTAssertTrue(err.description == "Error was was encountered in RpcProvider.")
+                if let origErr = err.originalError {
+                     XCTAssertTrue(origErr.code == 500)
+                } else {
+                     XCTFail()
+                }
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 30)
+        
+    }
+    
+    private func createBlockResponseJson() -> String {
+        let json = """
+            {
+                "timestamp": "2019-02-21T18:31:40.000",
+                "producer": "blkproducer2",
+                "confirmed": 0,
+                "previous": "01816fffa4548475add3c45d0e0620f59468a6817426137b37851c23ccafa9cc",
+                "transaction_mroot": "0000000000000000000000000000000000000000000000000000000000000000",
+                "action_mroot": "de5493939e3abdca80deeab2fc9389cc43dc1982708653cfe6b225eb788d6659",
+                "schedule_version": 3,
+                "new_producers": null,
+                "header_extensions": [],
+                "producer_signature": "SIG_K1_KZ3ptku7orAgcyMzd9FKW4jPC9PvjW9BGadFoyxdJFWM44VZdjW28DJgDe6wkNHAxnpqCWSzaBHB1AfbXBUn3HDzetemoA",
+                "transactions": [],
+                "block_extensions": [],
+                "id": "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116",
+                "block_num": 25260032,
+                "ref_block_prefix": 2249927103
+            }
+        """
+        
+        return json
+    }
+
+    
+}


### PR DESCRIPTION
I added 2 example tests showing how OHHTTPStubs works for testing.

The first example **testGetBlock()**  is the **happy path** when testing calling getBlock().

The second example testGetBlockServerError() is a test for a call failure due to a server issue.

Please take a look so we can have some feedback to this direction.

**This tool allows a whole set of functionality for completely testing the networking code**.  

There are  only **2 things it cannot simulate** due to how the Foundation networking calls are implemented by Apple (_since we do not use either of these in our networking code it isn't a big deal for us_): 

- Background sessions (sessions created using [**NSURLSessionConfiguration backgroundSessionConfiguration**]) because background sessions don't allow the use of custom NSURLProtocols and are handled by the iOS Operating System itself.

- Can't simulate **data upload**. The NSURLProtocolClient protocol does not provide a way to signal the delegate that data has been sent (only that some has been loaded), so any data in the HTTPBody or HTTPBodyStream of an NSURLRequest, or data provided to -[NSURLSession uploadTaskWithRequest:fromData:]; will be ignored, and more importantly, the -URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend: delegate method will never be called when you stub the request using OHHTTPStubs.