### PR TITLE
Switch to inline code doc styles as stubbed by Xcode.

### DIFF
--- a/EosioSwift/EosioAbiProviderProtocol/EosioAbiProvider.swift
+++ b/EosioSwift/EosioAbiProviderProtocol/EosioAbiProvider.swift
@@ -8,12 +8,16 @@
 
 import Foundation
 
+/// Default implementation of the `EosioAbiProviderProtocol`. For fetching and caching ABIs.
 public class EosioAbiProvider: EosioAbiProviderProtocol {
 
     private let rpcProvider: EosioRpcProviderProtocol
     private var abis = [String: Data]()
     private let lock = String()
 
+    /// Initialize the ABI Provider
+    ///
+    /// - Parameter rpcProvider: The RPC provider, which this ABI provider will use to fetch ABIs.
     public init(rpcProvider: EosioRpcProviderProtocol) {
         self.rpcProvider = rpcProvider
     }
@@ -28,9 +32,13 @@ public class EosioAbiProvider: EosioAbiProviderProtocol {
         objc_sync_exit(self.lock)
     }
 
-    /**
-     Return a map of Abis as Data for all of the given accounts, keyed by the account name. An Abi for each account must be returned, otherwise an EosioResult.failure type will be returned.
-     */
+    /// Get all ABIs for the given accounts, keyed by account name.
+    ///
+    /// - Parameters:
+    ///   - chainId: The chain ID.
+    ///   - accounts: An array of account names as `EosioName`s.
+    ///   - completion: Calls the completion with an `EosioResult` containing a map of ABIs as Data for all of the given accounts, keyed by the account name. An ABI for each account must be
+    ///     returned, otherwise an `EosioResult.failure` type will be returned.
     public func getAbis(chainId: String, accounts: [EosioName], completion: @escaping (EosioResult<[EosioName: Data], EosioError>) -> Void) {
         let accounts = Array(Set(accounts)) // remove any duplicate account names
         var responseAbis = [EosioName: Data]()
@@ -60,9 +68,13 @@ public class EosioAbiProvider: EosioAbiProviderProtocol {
         }
     }
 
-    /**
-     Return the Abi as Data for the specified account name. An EosioResult.failure type will be returned if the specified Abi could not be found or decoded properly.
-     */
+    /// Get the ABI as `Data` for the specified account name.
+    ///
+    /// - Parameters:
+    ///   - chainId: The chain ID.
+    ///   - account: The account name as an `EosioName`.
+    ///   - completion: Calls the completion with an `EosioResult` containing the ABI as Data. An `EosioResult.failure` type will be returned if the specified ABI could not be found
+    ///     or decoded properly.
     public func getAbi(chainId: String, account: EosioName, completion: @escaping (EosioResult<Data, EosioError>) -> Void) {
         if let abi = getCachedAbi(chainId: chainId, account: account) {
             return completion(.success(abi))

--- a/EosioSwift/EosioAbiProviderProtocol/EosioAbiProviderProtocol.swift
+++ b/EosioSwift/EosioAbiProviderProtocol/EosioAbiProviderProtocol.swift
@@ -8,14 +8,24 @@
 
 import Foundation
 
+/// Protocol for fetching and caching ABIs.
 public protocol EosioAbiProviderProtocol {
-    /**
-     Return a map of Abis as Data for all of the given accounts, keyed by the account name. An Abi for each account must be returned, otherwise an EosioResult.failure type will be returned.
-     */
+
+    /// Get all ABIs for the given accounts, keyed by account name.
+    ///
+    /// - Parameters:
+    ///   - chainId: The chain ID.
+    ///   - accounts: An array of account names as `EosioName`s.
+    ///   - completion: Calls the completion with an `EosioResult` containing a map of ABIs as Data for all of the given accounts, keyed by the account name. An ABI for each account must be
+    ///     returned, otherwise an `EosioResult.failure` type will be returned.
     func getAbis(chainId: String, accounts: [EosioName], completion: @escaping (EosioResult<[EosioName: Data], EosioError>) -> Void)
 
-    /**
-     Return the Abi as Data for the specified account name. An EosioResult.failure type will be returned if the specified Abi could not be found or decoded properly.
-     */
+    /// Get the ABI as `Data` for the specified account name.
+    ///
+    /// - Parameters:
+    ///   - chainId: The chain ID.
+    ///   - account: The account name as an `EosioName`.
+    ///   - completion: Calls the completion with an `EosioResult` containing the ABI as Data. An `EosioResult.failure` type will be returned if the specified ABI could not be found or
+    ///     decoded properly.
     func getAbi(chainId: String, account: EosioName, completion: @escaping (EosioResult<Data, EosioError>) -> Void)
 }

--- a/EosioSwift/EosioTransaction/EosioTransaction.swift
+++ b/EosioSwift/EosioTransaction/EosioTransaction.swift
@@ -9,9 +9,7 @@
 // swiftlint:disable line_length
 import Foundation
 
-/**
-    Class for creating, preparing, signing, and (optionally) broadcasting transactions on EOSIO-based blockchains.
-*/
+/// Class for creating, preparing, signing, and (optionally) broadcasting transactions on EOSIO-based blockchains.
 public class EosioTransaction: Codable {
 
     /// Chain ID in `String` format.
@@ -80,20 +78,16 @@ public class EosioTransaction: Codable {
         case transactionExtensions
     }
 
-    /**
-        Initializes the class.
-     */
+    /// Initializes the class.
     public init() {  }
 
-    /**
-        Deserialize a serialized transaction and return an `EosioTransaction` object.
-
-        - Parameters:
-            - serializedTransaction: A serialized transaction as Data.
-            - serializationProvider: A serialization provider. Will be used for transaction deserialization and set as the `serializationProvider` on the returned `EosioTransaction`.
-        - Returns: An `EosioTransaction`.
-        - Throws: If the transaction cannot be deserialized.
-    */
+    /// Deserialize a serialized transaction and return an `EosioTransaction` object.
+    ///
+    /// - Parameters:
+    ///   - serializedTransaction: A serialized transaction as Data.
+    ///   - serializationProvider: A serialization provider. Will be used for transaction deserialization and set as the `serializationProvider` on the returned `EosioTransaction`.
+    /// - Returns: An `EosioTransaction`.
+    /// - Throws: If the transaction cannot be deserialized.
     static public func deserialize(_ serializedTransaction: Data, serializationProvider: EosioSerializationProviderProtocol) throws -> EosioTransaction {
         let json = try serializationProvider.deserializeTransaction(hex: serializedTransaction.hex)
         guard let data = json.data(using: .utf8) else {
@@ -121,26 +115,21 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Encode the transaction as a json string. Properties will be snake_case. Action data will be serialized.
-
-        - Parameters:
-            - prettyPrinted: Should the json be pretty printed? (default = false)
-        - Returns: The transaction as a json string.
-        - Throws: If the transaction cannot be encoded to json.
-    */
+    /// Encode the transaction as a json string. Properties will be snake_case. Action data will be serialized.
+    ///
+    /// - Parameter prettyPrinted: Should the json be pretty printed? (default = false)
+    /// - Returns: The transaction as a json string.
+    /// - Throws: If the transaction cannot be encoded to json.
     public func toJson(prettyPrinted: Bool = false) throws -> String {
         return try self.toJsonString(convertToSnakeCase: true, prettyPrinted: prettyPrinted)
     }
 
-    /**
-        Serializes the transaction and returns a `Data` object. Serializing a transaction requires the `serializedData` property for all the actions to have a value and the TAPOS properties
-        (`refBlockNum`, `refBlockPrefix`, `expiration`) to have valid values. If the necessary data is not known to be set, call the asynchronous version of this method, which will attempt to
-        get the necessary data first.
-
-        - Returns: A `Data` object representing the serialized transaction.
-        - Throws: If any of the necessary data is missing or transaction cannot be serialized.
-     */
+    /// Serializes the transaction and returns a `Data` object. Serializing a transaction requires the `serializedData` property for all the actions to have a value and the TAPOS properties
+    /// (`refBlockNum`, `refBlockPrefix`, `expiration`) to have valid values. If the necessary data is not known to be set, call the asynchronous version of this method, which will attempt to
+    /// get the necessary data first.
+    ///
+    /// - Returns: A `Data` object representing the serialized transaction.
+    /// - Throws: If any of the necessary data is missing or transaction cannot be serialized.
     public func serializeTransaction() throws -> Data {
         try serializeActionData()
         guard refBlockNum > 0 else {
@@ -159,13 +148,10 @@ public class EosioTransaction: Codable {
         return try Data(hex: serializer.serializeTransaction(json: json))
     }
 
-    /**
-        Asynchronous version of serializeTransaction that calls `prepare(completion:)` before attemping to create a serialized transaction. If an error is encountered, this method will call the
-        completion with that error. Otherwise, the completion will be called with a serialized transaction.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of `Data` for success and an optional `EosioError`.
-     */
+    /// Asynchronous version of serializeTransaction that calls `prepare(completion:)` before attemping to create a serialized transaction. If an error is encountered, this method will call the
+    /// completion with that error. Otherwise, the completion will be called with a serialized transaction.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of `Data` for success and an optional `EosioError`.
     public func serializeTransaction(completion: @escaping (EosioResult<Data, EosioError>) -> Void) {
         prepare { [weak self] (result) in
             guard let strongSelf = self else {
@@ -185,13 +171,10 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Prepares the transaction, fetching or calculating any needed values by calling `calculateExpiration()`, `getChainIdAndCalculateTapos(completion:)`, and `serializeActionData(completion:)`.
-        If any of these methods returns an error, this method will call the completion with that error.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Prepares the transaction, fetching or calculating any needed values by calling `calculateExpiration()`, `getChainIdAndCalculateTapos(completion:)`, and `serializeActionData(completion:)`.
+    /// If any of these methods returns an error, this method will call the completion with that error.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func prepare(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
 
         getInfoAndSetValues { [weak self] (taposResult) in
@@ -207,12 +190,10 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Serializes the `data` property of each action in `actions` and sets the `serializedData` property for each action, if not already set. Serializing the action data requires ABIs to be available in
-        the `abis` class for all the contracts in the actions. If the necessary ABIs are not known to be available, call the asynchronous version of this method, which will attempt to get the ABIs first.
-
-        - Throws: If any required abis are not available, or the action `data` cannot be serialized.
-     */
+    /// Serializes the `data` property of each action in `actions` and sets the `serializedData` property for each action, if not already set. Serializing the action data requires ABIs to be available in
+    /// the `abis` class for all the contracts in the actions. If the necessary ABIs are not known to be available, call the asynchronous version of this method, which will attempt to get the ABIs first.
+    ///
+    /// - Throws: If any required abis are not available, or the action `data` cannot be serialized.
     public func serializeActionData() throws {
         let missingAbis = actionAccountsMissingAbis
         guard missingAbis.count == 0 else {
@@ -226,13 +207,10 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Calls `getABIs(completion:)` before attemping to serialize the actions data by calling `serializeActionData()`. If `getABIs(completion:)` returns an error, this method will call the completion with
-        that error. If `serializeActionData()` throws an error, the completion will be called with that error. If all action data is successfully serialized, the completion will be called with `true`.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Calls `getABIs(completion:)` before attemping to serialize the actions data by calling `serializeActionData()`. If `getABIs(completion:)` returns an error, this method will call the completion with
+    /// that error. If `serializeActionData()` throws an error, the completion will be called with that error. If all action data is successfully serialized, the completion will be called with `true`.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func serializeActionData(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         getAbis { [weak self] (abisResult) in
             guard let strongSelf = self else {
@@ -252,15 +230,12 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Gets ABIs for every contract in the actions using the `abiProvider` and adds them to `abis`. If ABIs are already present for all contracts, this method will not need to use the `abiProvider` and will
-        immediately call the completion with `true`. If the `abiProvider` is not set but the `rpcProvider` is, an `EosioAbiProvider` instance will be created using the `rpcProvider` and set as the `abiProvider`.
-        If the ABIs are not present and the `abiProvider` is not set or `abiProvider` cannot get some of the requested ABIs, an error is returned. If all ABIs are successfully set, this method will call the
-        completion with `true`.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Gets ABIs for every contract in the actions using the `abiProvider` and adds them to `abis`. If ABIs are already present for all contracts, this method will not need to use the `abiProvider` and will
+    /// immediately call the completion with `true`. If the `abiProvider` is not set but the `rpcProvider` is, an `EosioAbiProvider` instance will be created using the `rpcProvider` and set as the `abiProvider`.
+    /// If the ABIs are not present and the `abiProvider` is not set or `abiProvider` cannot get some of the requested ABIs, an error is returned. If all ABIs are successfully set, this method will call the
+    /// completion with `true`.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func getAbis(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         let missingAbis = actionAccountsMissingAbis
         // if no missing ABIs, return now
@@ -297,13 +272,10 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Gets chain info and sets the `chainId` and `expiration`. Then calculates the reference block number using the using the `config` property and calls `getBlockAndSetTapos(blockNum:, completion:)`.
-        If the `chainId` is already set, this method will validate against the `chainId` retreived from the `rpcProvider` and return an error if they do not match.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Gets chain info and sets the `chainId` and `expiration`. Then calculates the reference block number using the using the `config` property and calls `getBlockAndSetTapos(blockNum:, completion:)`.
+    /// If the `chainId` is already set, this method will validate against the `chainId` retreived from the `rpcProvider` and return an error if they do not match.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     private func getInfoAndSetValues(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
 
         // if all the data is set, just return true
@@ -351,15 +323,13 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Gets the block specified by `blockNum` and sets `refBlockNum` and `refBlockPrefix`. If `refBlockNum` and `refBlockPrefix` already have valid values, this method will call the completion with `true`.
-        If these properties do not have valid values, this method will require an `rpcProvider` to get the data for these values. If the `rpcProvider` is not set or another error is encountered, this method
-        will call the completion with an error.
-
-        - Parameters:
-            - blockNum: The block number serving as the basis for TAPOS calculations.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Gets the block specified by `blockNum` and sets `refBlockNum` and `refBlockPrefix`. If `refBlockNum` and `refBlockPrefix` already have valid values, this method will call the completion with `true`.
+    /// If these properties do not have valid values, this method will require an `rpcProvider` to get the data for these values. If the `rpcProvider` is not set or another error is encountered, this method
+    /// will call the completion with an error.
+    ///
+    /// - Parameters:
+    ///   - blockNum: The block number serving as the basis for TAPOS calculations.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func getBlockAndSetTapos(blockNum: UInt64, completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         // if the only data needed was the chainId, return now
         if self.refBlockPrefix > 0 && self.refBlockNum > 0 {
@@ -388,12 +358,9 @@ public class EosioTransaction: Codable {
         })
     }
 
-    /**
-        Signs a transaction by getting the available keys from the `signatureProvider` and calling `sign(availableKeys:, completion:)`.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Signs a transaction by getting the available keys from the `signatureProvider` and calling `sign(availableKeys:, completion:)`.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func sign(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         guard let signatureProvider = signatureProvider else {
             return completion(.failure(EosioError(.signatureProviderError, reason: "No signature provider available")))
@@ -409,13 +376,11 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Signs a transaction by preparing the transaction and calling `signPreparedTransaction(availableKeys:, completion:)`.
-
-        - Parameters:
-            - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Signs a transaction by preparing the transaction and calling `signPreparedTransaction(availableKeys:, completion:)`.
+    ///
+    /// - Parameters:
+    ///   - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func sign(availableKeys: [String], completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         prepare { [weak self] (result) in
             guard let strongSelf = self else {
@@ -430,13 +395,11 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Signs a transaction by getting the required keys using the `rpcProvider` and calling `sign(publicKeys:, completion:)`.
-
-        - Parameters:
-            - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Signs a transaction by getting the required keys using the `rpcProvider` and calling `sign(publicKeys:, completion:)`.
+    ///
+    /// - Parameters:
+    ///   - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     private func signPreparedTransaction(availableKeys: [String], completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         guard let rpcProvider = rpcProvider else {
             return completion(.failure(EosioError(.signatureProviderError, reason: "No rpc provider available")))
@@ -452,13 +415,11 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Serializes the transaction and then signs with the private keys corresponding to the passed-in public keys. If successful, sets the `signatures` and returns `true`. Otherwise returns an error.
-
-        - Parameters:
-            - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Serializes the transaction and then signs with the private keys corresponding to the passed-in public keys. If successful, sets the `signatures` and returns `true`. Otherwise returns an error.
+    ///
+    /// - Parameters:
+    ///   - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func sign(publicKeys: [String], completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         self.serializeTransaction { [weak self] (result) in
             guard let strongSelf = self else {
@@ -473,14 +434,12 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Signs the passed-in `serializedTransaction` with the private keys corresponding to the provided public keys. If successful, sets the `signatures` and returns `true`. Otherwise returns an error.
-
-        - Parameters:
-            - serializedTransaction: The serialized transaction as `Data`.
-            - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Signs the passed-in `serializedTransaction` with the private keys corresponding to the provided public keys. If successful, sets the `signatures` and returns `true`. Otherwise returns an error.
+    ///
+    /// - Parameters:
+    ///   - serializedTransaction: The serialized transaction as `Data`.
+    ///   - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     private func sign(serializedTransaction: Data, publicKeys: [String], completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         guard let signatureProvider = signatureProvider else {
             return completion(.failure(EosioError(.signatureProviderError, reason: "No signature provider available")))
@@ -509,15 +468,13 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Process a signed transaction. If the transaction has been modified by the signature provider, it deserializes the signed transaction and updates/sets the `EosioTransaction` properties. If the
-        original transaction was set to disallow modifications by the signature provider, an error is returned instead.
-
-        - Parameters:
-            - signedTransaction: A signed transaction.
-            - originalSerializedTransaction: The original serialized transaction, as `Data`.
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Process a signed transaction. If the transaction has been modified by the signature provider, it deserializes the signed transaction and updates/sets the `EosioTransaction` properties. If the
+    /// original transaction was set to disallow modifications by the signature provider, an error is returned instead.
+    ///
+    /// - Parameters:
+    ///   - signedTransaction: A signed transaction.
+    ///   - originalSerializedTransaction: The original serialized transaction, as `Data`.
+    ///   - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     private func process(signedTransaction: EosioTransactionSignatureResponse.SignedTransaction, originalSerializedTransaction: Data, completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         if signedTransaction.serializedTransaction == originalSerializedTransaction {
             self.serializedTransaction = signedTransaction.serializedTransaction
@@ -556,12 +513,9 @@ public class EosioTransaction: Codable {
 
     }
 
-    /**
-        Broadcasts a signed transaction. If successful, sets the `transactionId` and returns `true`. Otherwise returns an error.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Broadcasts a signed transaction. If successful, sets the `transactionId` and returns `true`. Otherwise returns an error.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func broadcast(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         guard let serializedTransaction = serializedTransaction, let signatures = signatures, signatures.count > 0 else {
             return completion(.failure(EosioError(.eosioTransactionError, reason: "Transaction must be signed before broadcast")))
@@ -586,12 +540,9 @@ public class EosioTransaction: Codable {
         }
     }
 
-    /**
-        Signs a transaction and then broadcasts it.
-
-        - Parameters:
-            - completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
-     */
+    /// Signs a transaction and then broadcasts it.
+    ///
+    /// - Parameter completion: Called with an `EosioResult` consisting of a `Bool` for success and an optional `EosioError`.
     public func signAndBroadcast(completion: @escaping (EosioResult<Bool, EosioError>) -> Void) {
         sign { [weak self] (result) in
             guard let strongSelf = self else {

--- a/EosioSwift/Extensions/ArrayExtensions.swift
+++ b/EosioSwift/Extensions/ArrayExtensions.swift
@@ -31,9 +31,8 @@ public extension Array {
 }
 
 public extension Array where Element == String {
-    /**
-     Returns JSON String representation of an array.
-     */
+
+    /// Returns JSON String representation of an array.
     var jsonStringArray: String {
         if let data = try? JSONSerialization.data(withJSONObject: self, options: []), let jsonString = String(data: data, encoding: .utf8) {
             return jsonString
@@ -50,9 +49,8 @@ public protocol JsonOutput {
 }
 
 public extension Array where Element == JsonOutput {
-    /**
-     Returns JSON string representation of an array where the element type conforms to JsonOutput protocol.
-     */
+
+    /// Returns JSON string representation of an array where the element type conforms to JsonOutput protocol.
     var json: String {
         guard self.count > 0 else {
             return "[]"

--- a/EosioSwift/Extensions/DataExtensions.swift
+++ b/EosioSwift/Extensions/DataExtensions.swift
@@ -13,9 +13,9 @@ public extension Data {
 
     private static let hexAlphabet = "0123456789abcdef".unicodeScalars.map { $0 }
 
-    /**
-     Returns Base16 encoded string representation of the data.
-     */
+    /// Get a hex-encoded string representation of the data.
+    ///
+    /// - Returns: Base16 encoded string representation of the data.
     func hexEncodedString() -> String {
         return String(self.reduce(into: "".unicodeScalars, { (result, value) in
             result.append(Data.hexAlphabet[Int(value/16)])
@@ -28,7 +28,7 @@ public extension Data {
         return self.hexEncodedString()
     }
 
-    /// Init a `Data` object with a base64 string
+    /// Init a `Data` object with a base64 string.
     ///
     /// - Parameter base64: The data encoded as a base64 string
     /// - Throws: If the string is not a valid base64 string
@@ -53,12 +53,9 @@ public extension Data {
         self = data
     }
 
-    /**
-     Initializes a data object from a Base16 encoded string.
-
-     - Parameters:
-     - hexString: A Base16 encoded string.
-     */
+    /// Initializes a data object from a Base16 encoded string.
+    ///
+    /// - Parameter hexString: A Base16 encoded string.
     init?(hexString: String) {
         let len = hexString.count / 2
         var data = Data(capacity: len)
@@ -75,9 +72,7 @@ public extension Data {
         self = data
     }
 
-    /**
-     Returns the SHA256 hash of the data.
-     */
+    /// Returns the SHA256 hash of the data.
     var sha256: Data {
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
         self.withUnsafeBytes {
@@ -86,18 +81,15 @@ public extension Data {
         return Data(bytes: hash)
     }
 
-    /**
-     Returns the current Data as a base58 encoded String.
-     */
+    /// Returns the current Data as a base58 encoded String.
     var base58EncodedString: String {
         return String(base58Encoding: self)
     }
 
-    /**
-     Decodes the given base58 String and returns it as Data, if valid.
-     - Parameters:
-     - base58: A Base58 encoded string.
-     */
+    /// Decodes the given base58 String and returns it as Data, if valid.
+    ///
+    /// - Parameter base58: A Base58 encoded string.
+    /// - Returns: The base58 String as Data.
     static func decode(base58: String) -> Data? {
         return Data(base58Decoding: base58)
     }

--- a/EosioSwift/Extensions/DateExtensions.swift
+++ b/EosioSwift/Extensions/DateExtensions.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public extension Date {
 
-    /**
-     Returns the current data and time as a timestamp.
-     */
+    /// Get the current date and time, formatted.
+    ///
+    /// - Returns: The current data and time as a timestamp.
     static func getFormattedTime() -> String {
         let now = Date()
         let dateFormatter = DateFormatter()
@@ -22,13 +22,10 @@ public extension Date {
         return timeString
     }
 
-    /**
-     Initializes a `Data` object from a timestamp string.
-
-     - Parameters:
-     - yyyyMMddTHHmmss: The timestamp string.
-     - Returns: A `Date` object or `nil` if the timestamp string can't be converted to `Date`.
-     */
+    /// Initializes a `Data` object from a timestamp string.
+    ///
+    /// - Parameter yyyyMMddTHHmmss: The timestamp string.
+    /// - Returns: `nil` if the timestamp string cannot be converted to a `Date`.
     init?(yyyyMMddTHHmmss: String?) {
         guard let yyyyMMddTHHmmss = yyyyMMddTHHmmss else { return nil }
         let formatter = DateFormatter()
@@ -42,9 +39,7 @@ public extension Date {
         }
     }
 
-    /**
-     Returns a string representation of the `Date` object.
-     */
+    /// Returns a string representation of the `Date` object.
     var yyyyMMddTHHmmss: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
@@ -53,9 +48,7 @@ public extension Date {
         return formatter.string(from: self)
     }
 
-    /**
-     Returns a DateFormatter instance customized for `JSONEncoder.dateEncodingStrategy`
-     */
+    /// Returns a DateFormatter instance customized for `JSONEncoder.dateEncodingStrategy`.
     static let asTransactionTimestamp: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"

--- a/EosioSwift/Extensions/DictionaryExtensions.swift
+++ b/EosioSwift/Extensions/DictionaryExtensions.swift
@@ -9,11 +9,8 @@
 import Foundation
 
 public extension Dictionary {
-    /**
-     Encodes the dictionary to a JSON string.
 
-     - Returns: A JSON string representation of the dictionary or nil if the dictionary can't be encoded to a JSON string.
-     */
+    /// Returns a JSON string representation of the dictionary or nil if the dictionary can't be encoded to a JSON string.
     var jsonString: String? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: self, options: [.sortedKeys]) else { return nil }
         return String(data: jsonData, encoding: .utf8)

--- a/EosioSwift/Extensions/EncodableExtensions.swift
+++ b/EosioSwift/Extensions/EncodableExtensions.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public extension Encodable {
 
-    /// Encodes an `Encodable` object as a json string
+    /// Encodes an `Encodable` object as a json string.
     ///
     /// - Parameters:
     ///   - convertToSnakeCase: should camelCase keys be converted to snake_case? (default = false)
     ///   - prettyPrinted: should the output be prettyPrinted? (default = false)
-    /// - Returns: a json string
-    /// - Throws: if the object cannot be encoded to json
+    /// - Returns: A json string.
+    /// - Throws: If the object cannot be encoded to json.
     func toJsonString(convertToSnakeCase: Bool = false, prettyPrinted: Bool = false) throws -> String {
         let jsonData = try self.toJsonData(convertToSnakeCase: convertToSnakeCase, prettyPrinted: prettyPrinted)
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
@@ -25,15 +25,13 @@ public extension Encodable {
         return jsonString
     }
 
-    /**
-     Encodes an `Encodable` object as a json string
-
-     - Parameters:
-     - convertToSnakeCase: should camelCase keys be converted to snake_case? (default = false)
-     - prettyPrinted: should the output be prettyPrinted? (default = false)
-     - Returns: a Data object.
-     - Throws: if the object cannot be encoded into a JSON object.
-     */
+    /// Encodes an `Encodable` object as a json string.
+    ///
+    /// - Parameters:
+    ///   - convertToSnakeCase: should camelCase keys be converted to snake_case? (default = false)
+    ///   - prettyPrinted: should the output be prettyPrinted? (default = false)
+    /// - Returns: a Data object.
+    /// - Throws: If the object cannot be encoded into a JSON object.
     func toJsonData(convertToSnakeCase: Bool = false, prettyPrinted: Bool = false) throws -> Data {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = [.sortedKeys]
@@ -48,9 +46,9 @@ public extension Encodable {
         return try jsonEncoder.encode(self)
     }
 
-    /// Encodces an `Encodable` object as a dictionary of type `[String:Any]`
+    /// Encodes an `Encodable` object as a dictionary of type `[String: Any]`.
     ///
-    /// - Returns: a dictionary of type `[String:Any]`
+    /// - Returns: A dictionary of type `[String: Any]`.
     func toDictionary() -> [String: Any]? {
         guard let json = try? self.toJsonString() else { return nil }
         return json.toJsonDictionary

--- a/EosioSwift/Extensions/StringExtensions.swift
+++ b/EosioSwift/Extensions/StringExtensions.swift
@@ -10,9 +10,7 @@ import Foundation
 
 public extension String {
 
-    /**
-     Returns the domain (host) component of a url
-     */
+    /// Returns the domain (host) component of a url.
     var urlDomain: String? {
         var string = self
         if !string.contains("://") {
@@ -21,14 +19,12 @@ public extension String {
         return URL(string: string)?.host
     }
 
-    /**
-     Slices the string starting from `from` and ending at the start of the `to` string.
-
-     - Parameters:
-     - from: the begining of the slice.
-     - to: the end of the slice.
-     - Returns: String?
-     */
+    /// Slices the string starting from `from` and ending at the start of the `to` string.
+    ///
+    /// - Parameters:
+    ///   - from: the begining of the slice.
+    ///   - to: the end of the slice.
+    /// - Returns: String?
     func slice(from: String, to: String) -> String? { // swiftlint:disable:this identifier_name
         return (range(of: from)?.upperBound).flatMap { substringFrom in
             (range(of: to, range: substringFrom..<endIndex)?.lowerBound).map { substringTo in
@@ -37,13 +33,10 @@ public extension String {
         }
     }
 
-    /**
-     Returns all the strings that match a regular expression.
-
-     - Parameters:
-     - regex: The string to use as a regular expression.
-     - Returns: An array of all the matched string or empty if no match were found.
-     */
+    /// Returns all the strings that match a regular expression.
+    ///
+    /// - Parameter regex: The string to use as a regular expression.
+    /// - Returns: An array of all the matched string or empty if no match were found.
     func matchingStrings(regex: String) -> [[String]] {
         guard let regex = try? NSRegularExpression(pattern: regex, options: []) else { return [] }
         let nsString = self as NSString
@@ -57,30 +50,24 @@ public extension String {
         }
     }
 
-    /**
-     Returns `true` if the string is an absolute URL else returns `false`.
-     */
+    /// Is the string an absolute URL?
+    ///
+    /// - Returns: Returns `true` if the string is an absolute URL else returns `false`.
     func isAbsoluteURL() -> Bool {
         return self.lowercased().contains("http://") || self.lowercased().contains("https://")
     }
 
-    /**
-     Converts the string to a dictionary if it is convertible to a dictionary i.e. it is a JSON string.
-
-     - Returns: A dictionary if the text is a JSON string and convertible to a dictionary otherwise returns `nil`.
-     */
+    /// Converts the string to a dictionary if it is convertible to a dictionary (i.e., it is a JSON string.) and returns the dictionary. Otherwise, returns `nil`.
     var toJsonDictionary: [String: Any]? {
         guard let data = self.data(using: .utf8) else { return nil }
         let dict = (try? JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any]) ?? nil
         return dict
     }
 
-    /**
-     Converts the string to a dictionary if it is convertible to a dictionary i.e. it is a JSON string.
-
-     - Returns: A dictionary if the text is a JSON string and convertible to a dictionary otherwise returns `nil`.
-     - Throws: A `EosioError` if the string can not be converted to a dictionary.
-     */
+    /// Converts the string to a dictionary if it is convertible to a dictionary (i.e., it is a JSON string.)
+    ///
+    /// - Returns: A dictionary if the text is a JSON string and convertible to a dictionary otherwise returns `nil`.
+    /// - Throws: A `EosioError` if the string can not be converted to a dictionary.
     func jsonToDictionary() throws -> [String: Any] {
         guard let data = self.data(using: .utf8) else {
             throw EosioError(.deserializeError, reason: "Cannot create json from data")
@@ -92,12 +79,10 @@ public extension String {
         return dict
     }
 
-    /**
-     Converts an object to a JSON string if possible.
-     - Parameters:
-     - jsonObject: An object to convert to JSON string.
-     - Returns: A string if the object is convertible to JSON string or nil.
-     */
+    /// Converts an object to a JSON string if possible.
+    ///
+    /// - Parameter jsonObject: An object to convert to JSON string.
+    /// - Returns: A string if the object is convertible to JSON string or nil.
     static func jsonString(jsonObject: Any?) -> String? {
         guard let object = jsonObject else { return nil }
         if let string = object as? String {
@@ -109,14 +94,10 @@ public extension String {
         return nil
     }
 
-    /**
-     Initializes a string from an object that conforms to `Encodable` protocol.
-
-     - Parameters:
-     - encodeToJson: An object that conforms to `Encodable` protocol.
-     - Throws: EosioError if the passed object is not convertible to JSON string.
-
-     */
+    /// Initializes a string from an object that conforms to `Encodable` protocol.
+    ///
+    /// - Parameter encodeToJson: An object that conforms to `Encodable` protocol.
+    /// - Throws: EosioError if the passed object is not convertible to JSON string.
     init<T: Encodable>(encodeToJson: T) throws {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
@@ -129,10 +110,7 @@ public extension String {
         }
     }
 
-    /**
-     Returns Bool indicating whether the current string is a validly encode base58 string.
-
-     */
+    /// Returns Bool indicating whether the current string is a validly encode base58 string.
     var isValidBase58: Bool {
         guard Data(base58Decoding: self) != nil else {
             return false
@@ -140,7 +118,10 @@ public extension String {
         return true
     }
 
-    /// Returns true if the string contains all of the words in `words`
+    /// Does the string contain all of the provided words?
+    ///
+    /// - Parameter words: Words to look for in the string.
+    /// - Returns: Returns true if the string contains all of the words in `words`. Otherwise, false.
     func contains(words: String) -> Bool {
         guard self.count > 0, words.count > 0 else { return false }
         let components = self.components(separatedBy: " ")

--- a/EosioSwift/Foundation/EosioError.swift
+++ b/EosioSwift/Foundation/EosioError.swift
@@ -45,9 +45,8 @@ open class EosioError: Error, CustomStringConvertible, Codable {
         case errorCode
         case reason
     }
-    /**
-     Returns a JSON string representation of the error object.
-     */
+
+    /// Returns a JSON string representation of the error object.
     var errorAsJsonString: String {
         let jsonDict = [
             "errorType": "EosioError",


### PR DESCRIPTION
We had decided to use the

```swift
/**
    Docs here...
*/
```

style for inline code docs in Swift. But @Todd-Bowden pointed out that Xcode will stub these docs out for you (Editor > Structure > Add Documentation), and when it does, it uses the `///` style. 

So because Xcode is opinionated about it, I'm switching everything over to this.