### PR TITLE
Corrects Swift linting issue from last PR.  Enhances error information

### DIFF
--- a/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
+++ b/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
@@ -302,7 +302,7 @@ public struct EosioRpcProvider {
                     resource._rawResponse = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
                     callBack(resource, nil)
                 } catch let error {
-                    callBack(nil, EosioError(.rpcProviderError, reason: "Error occured in decoding/serializing returned data.", originalError: error as NSError))
+                    callBack(nil, EosioError(.rpcProviderError, reason: "Error occurred in decoding/serializing returned data.", originalError: error as NSError))
                 }
             }
         }

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -72,7 +72,7 @@ class EosioRpcProviderTests: XCTestCase {
                 print("\(blockResponse)")
                 XCTFail("testBadResponseDataHandled should have not returned a successful completion.")
             case .failure(let err):
-                XCTAssertTrue(err.reason == "Error occured in decoding/serializing returned data.")
+                XCTAssertTrue(err.reason == "Error occurred in decoding/serializing returned data.")
             }
             expect.fulfill()
         }


### PR DESCRIPTION
Enhances information in error passed back on failure in the getResource code in the RpcProvider that attempts to decode and serialize the returned data.  

Both failure cases now return enough error information so as to allow proper debugging and trouble shooting.  Other tests updated to process the new failure information correctly.