### PR TITLE
More Promises added to Transaction class.

### DIFF
--- a/EosioSwift/EosioTransaction/EosioTransactionPromises.swift
+++ b/EosioSwift/EosioTransaction/EosioTransactionPromises.swift
@@ -12,51 +12,68 @@ import PromiseKit
 extension EosioTransaction {
     /// Promised based method for signing a transaction and then broadcasting it.
     ///
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
+    ///
     /// Returns Promise<Bool>.
-    public func signAndBroadcast() -> Promise<Bool> {
+    public func signAndBroadcast(_: PMKNamespacer) -> Promise<Bool> {
         return Promise { signAndBroadcast(completion: $0.resolve) }
     }
     /// Promised based method for signing a transaction.
     ///
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
+    ///
     /// Returns Promise<Bool>.
-    public func sign() -> Promise<Bool> {
+    public func sign(_: PMKNamespacer) -> Promise<Bool> {
         return Promise { sign(completion: $0.resolve) }
     }
     /// Promised based method for signing a transaction with available keys.
     ///
     /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
     ///   - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
     ///
     /// Returns Promise<Bool>.
-    public func sign(availableKeys: [String]) -> Promise<Bool> {
+    public func sign(_: PMKNamespacer, availableKeys: [String]) -> Promise<Bool> {
         return Promise { sign (availableKeys: availableKeys, completion: $0.resolve) }
     }
     // public func sign(publicKeys: [String], completion: @escaping (EosioResult<Bool, EosioError>) -> Void)
     /// Promised based method for signing a transaction with publicKeys keys.
     ///
     /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
     ///   - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
     ///
     /// Returns Promise<Bool>.
-    public func sign(publicKeys: [String]) -> Promise<Bool> {
+    public func sign(_: PMKNamespacer, publicKeys: [String]) -> Promise<Bool> {
         return Promise { sign (publicKeys: publicKeys, completion: $0.resolve) }
     }
     /// Promised based method for broadcast a transaction.
     ///
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
+    ///
     /// Returns Promise<Bool>.
-    public func broadcast() -> Promise<Bool> {
+    public func broadcast(_: PMKNamespacer) -> Promise<Bool> {
         return Promise { broadcast(completion: $0.resolve) }
     }
     /// Promised based method to serialize a transaction.
     ///
-    /// Returns Promise<Bool>.
-    public func promiseSerializeTransaction() -> Promise<Data> {
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
+    ///
+    /// Returns Promise<Data>.
+    public func serializeTransaction(_: PMKNamespacer) -> Promise<Data> {
         return Promise { serializeTransaction(completion: $0.resolve) }
     }
     /// Promised based method to prepare a transaction.
     ///
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning function. Pass in `.promise` as the first parameter to call this method.
+    ///
     /// Returns Promise<Bool>.
-    public func prepare() -> Promise<Bool> {
+    public func prepare(_: PMKNamespacer) -> Promise<Bool> {
         return Promise { prepare(completion: $0.resolve) }
     }
 }

--- a/EosioSwiftTests/EosioTransactionTests.swift
+++ b/EosioSwiftTests/EosioTransactionTests.swift
@@ -183,7 +183,7 @@ class EosioTransactionTests: XCTestCase {
     // MARK: - EosioTransaction extension tests using Promises
     func test_signAndbroadcastPromise_shouldSucceed() {
         let expect = expectation(description: "signAndbroadcastPromise_shouldSucceed")
-        let promise = self.transaction.signAndBroadcast()
+        let promise = self.transaction.signAndBroadcast(.promise)
         promise.done { (value) in
             print(value)
             expect.fulfill()
@@ -192,9 +192,24 @@ class EosioTransactionTests: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
+    func test_signAndbroadcastPromise_shouldFail() {
+        let expect = expectation(description: "test_signAndbroadcastPromise_shouldFail")
+        let signatureProvider = SignatureProviderMock()
+        signatureProvider.getAvailableKeysShouldReturnFailure = true
+        self.transaction.signatureProvider = signatureProvider
+        let promise = self.transaction.signAndBroadcast(.promise)
+        promise.done { (value) in
+            print(value)
+            XCTFail("Should have throw error!")
+            }.catch { (error) in
+                print(error)
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
     func test_signPromise_shouldSucceed() {
         let expect = expectation(description: "signPromise_shouldSucceed")
-        let promise = self.transaction.sign()
+        let promise = self.transaction.sign(.promise)
         promise.done { (value) in
             print(value)
             expect.fulfill()
@@ -206,7 +221,7 @@ class EosioTransactionTests: XCTestCase {
     func test_signPromise_shouldFail() {
         let expect = expectation(description: "signPromise_shouldFail")
         self.transaction.signatureProvider = nil
-        self.transaction.sign().done { (value) in
+        self.transaction.sign(.promise).done { (value) in
             print(value)
             XCTFail("Should have throw error!")
             }.catch { _ in
@@ -217,10 +232,10 @@ class EosioTransactionTests: XCTestCase {
     func test_broadcastPromise_shouldSucceed() {
         let expect = expectation(description: "broadcastPromise_shouldSucceed")
         firstly {
-            self.transaction.sign()
+            self.transaction.sign(.promise)
             }.then { (value: Bool) -> Promise<Bool> in
                 print(value)
-                return self.transaction.broadcast()
+                return self.transaction.broadcast(.promise)
             }.done { (value) in
                 print(value)
                 expect.fulfill()
@@ -231,8 +246,9 @@ class EosioTransactionTests: XCTestCase {
     }
     func test_broadcastPromise_shouldFail() {
         let expect = expectation(description: "test_broadcastPromise_shouldFail")
+        //broadcast should fail as transaction needs to be signed first
         firstly {
-            self.transaction.broadcast()
+            self.transaction.broadcast(.promise)
             }.done { (value) in
                 print(value)
                 XCTFail("Should have throw error!")
@@ -241,6 +257,104 @@ class EosioTransactionTests: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
+    func test_signWithAvailableKeys_shouldSucceed() {
+        let expect = expectation(description: "test_signWithAvailableKeys_shouldSucceed")
+        let promise = self.transaction.sign(.promise, availableKeys: ["PUB_K1_5AzPqKAx4caCrRSAuyojY6rRKA3KJf4A1MY3paNVqV5eGGP63Y"])
+        promise.done { (value) in
+            print(value)
+            expect.fulfill()
+            }.catch { (error) in
+                XCTFail("Should not have throw error: \(error.localizedDescription)")
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_signWithAvailableKeys_shouldFail() {
+        let expect = expectation(description: "test_signWithAvailableKeys_shouldFail")
+        rpcProvider.getRequiredKeysReturnsfailure = true
+        let promise = self.transaction.sign(.promise, availableKeys: ["bad_key"])
+        promise.done { (value) in
+            print(value)
+            XCTFail("Should have throw error!)")
+            }.catch { (error) in
+                print(error)
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_signWithPublicKeys_shouldSucceed() {
+        let expect = expectation(description: "test_signWithPublicKeys_shouldSucceed")
+        let promise = self.transaction.sign(.promise, publicKeys: ["PUB_K1_5AzPqKAx4caCrRSAuyojY6rRKA3KJf4A1MY3paNVqV5eGGP63Y"])
+        promise.done { (value) in
+            print(value)
+            expect.fulfill()
+            }.catch { (error) in
+                XCTFail("Should not have throw error: \(error.localizedDescription)")
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_signWithPublicKeys_shouldFail() {
+        let expect = expectation(description: "test_signWithPublicKeys_shouldFail")
+        let promise = self.transaction.sign(.promise, publicKeys: ["bad_key"])
+        promise.done { (value) in
+            print(value)
+            XCTFail("Should have throw error!)")
+            }.catch { (error) in
+                print(error)
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_serializeTransaction_shouldSucceed() {
+        let expect = expectation(description: "test_serializeTransaction_shouldSucceed")
+        let promise = self.transaction.serializeTransaction(.promise)
+        promise.done { (value) in
+            print(value)
+            expect.fulfill()
+            }.catch { (error) in
+                XCTFail("Should not have throw error: \(error.localizedDescription)")
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_serializeTransaction_shouldFail() {
+        let expect = expectation(description: "test_serializeTransaction_shouldFail")
+        let serializationProvider = SerializationProviderMock()
+        serializationProvider.serializeTransactionReturnsfailure = true
+        self.transaction.serializationProvider = serializationProvider
+        let promise = self.transaction.serializeTransaction(.promise)
+        promise.done { (value) in
+            print(value)
+            XCTFail("Should have throw error!)")
+            }.catch { (error) in
+                print(error)
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_prepare_shouldSucceed() {
+        let expect = expectation(description: "test_prepare_shouldSucceed")
+        let promise = self.transaction.prepare(.promise)
+        promise.done { (value) in
+            print(value)
+            expect.fulfill()
+            }.catch { (error) in
+                XCTFail("Should not have throw error: \(error.localizedDescription)")
+        }
+        waitForExpectations(timeout: 10)
+    }
+    func test_prepare_shouldFail() {
+        let expect = expectation(description: "test_prepare_shouldFail")
+        rpcProvider.getInfoReturnsfailure = true
+        let promise = self.transaction.prepare(.promise)
+        promise.done { (value) in
+            print(value)
+            XCTFail("Should have throw error!)")
+            }.catch { (error) in
+                print(error)
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+    //public func prepare(_: PMKNamespacer) -> Promise<Bool>
 }
 
 class RPCProviderMock: EosioRpcProviderProtocol {
@@ -349,13 +463,18 @@ class RPCProviderMock: EosioRpcProviderProtocol {
 
 final class SerializationProviderMock: EosioSerializationProviderProtocol {
     var error: String?
+    var serializeTransactionReturnsfailure = false
 
     func serializeAbi(json: String) throws -> String {
         return ""
     }
 
     func serializeTransaction(json: String) throws -> String {
-        return ""
+        if serializeTransactionReturnsfailure {
+            throw EosioError(EosioErrorCode.serializeError, reason: "Test should have expected this failure.")
+        } else {
+           return ""
+        }
     }
 
     func serialize(contract: String?, name: String, type: String?, json: String, abi: String) throws -> String {
@@ -390,6 +509,8 @@ class AbiProviderMockup: EosioAbiProviderProtocol {
 
 class SignatureProviderMock: EosioSignatureProviderProtocol {
 
+    var getAvailableKeysShouldReturnFailure = false
+    
     func signTransaction(request: EosioTransactionSignatureRequest, completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
         var transactionSignatureResponse = EosioTransactionSignatureResponse()
 
@@ -398,6 +519,7 @@ class SignatureProviderMock: EosioSignatureProviderProtocol {
             signedTransaction.signatures = ["SIG_K1_EsykzHxjT3BN8nUvwsiLVddddDi6WRuYaen7sfmJxE88EjLMp4kvSRjQE1iXuRfuwiaSUJLi1xFHjUVhfbBYJDVE27uGFU8R3E1Er"]
             transactionSignatureResponse.signedTransaction = signedTransaction
         } else {
+            transactionSignatureResponse.signedTransaction = nil
             transactionSignatureResponse.error = EosioError(EosioErrorCode.signatureProviderError, reason: "Key not available")
         }
 
@@ -406,7 +528,13 @@ class SignatureProviderMock: EosioSignatureProviderProtocol {
 
     func getAvailableKeys(completion: @escaping (EosioAvailableKeysResponse) -> Void) {
         var availableKeysResponse = EosioAvailableKeysResponse()
-        availableKeysResponse.keys = ["PUB_K1_5AzPqKAx4caCrRSAuyojY6rRKA3KJf4A1MY3paNVqV5eGGP63Y"]
+        
+        if getAvailableKeysShouldReturnFailure == true {
+            availableKeysResponse.error = EosioError(EosioErrorCode.signatureProviderError, reason: "Expected error for testing.")
+            
+        } else {
+            availableKeysResponse.keys = ["PUB_K1_5AzPqKAx4caCrRSAuyojY6rRKA3KJf4A1MY3paNVqV5eGGP63Y"]
+        }
         completion(availableKeysResponse)
     }
 }


### PR DESCRIPTION
Implement for Promises for:
sign(availableKeys:)
sign(publicKeys:)
prepare(completion:)
serializeTransaction(completion:)

Success and failing test / expectations added.
Failing expectation tests added for prior promises.
Refactored prior promises to use new resolver pattern and PMKNamespacer.