### PR TITLE
RPC: Avoid hang if ref to self lost.

### DIFF
--- a/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
+++ b/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
@@ -44,6 +44,7 @@ public class EosioRpcProvider {
     ) {
         DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self = self else {
+                callBack(nil, EosioError(.unexpectedError, reason: "self does not exist", originalError: nil))
                 return
             }
             var exitLoop = false
@@ -113,6 +114,7 @@ public class EosioRpcProvider {
         }
         DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self = self else {
+                callBack(nil, EosioError(.unexpectedError, reason: "self does not exist", originalError: nil))
                 return
             }
             let url = URL(string: "v1/" + rpc, relativeTo: endpoint)!


### PR DESCRIPTION
This addresses something @Todd-Bowden pointed out. If there's no reference to self, the callback should be called with an error. Otherwise, the callback will never be called.

This is a net new addition as well, so I didn't want to slip it in with other refactor work.