### PR TITLE
Inline docs: EosioError, EosioErrorCode, EosioResult, Error.eosioError.

### DIFF
--- a/EosioSwift/Foundation/EosioError.swift
+++ b/EosioSwift/Foundation/EosioError.swift
@@ -8,37 +8,83 @@
 
 import Foundation
 
+/// Error codes for `EosioError`.
+///
+/// - eosioTransactionError: Error was encountered while preparing the Transaction.
+/// - rpcProviderError: Error was encountered in RpcProvider.
+/// - getInfoError: Error was returned by getInfo() method.
+/// - getBlockError: Error was encountered from getBlock() method.
+/// - getRequiredKeysError: Error was returned by getRequiredKeys() method.
+/// - getRawAbiError: Error was returned by getRawAbi() method.
+/// - pushTransactionError: Error was encountered while pushing the transaction.
+/// - signatureProviderError: Error was encountered in SignatureProvider.
+/// - getAvailableKeysError: Error was returned by getAvailableKeys() method.
+/// - signTransactionError: Error was encountered while signing the transaction.
+/// - abiProviderError: Error was encountered in AbiProvider.
+/// - getAbiError: Error was returned by getAbi() method.
+/// - serializationProviderError: Error was encountered in SerializationProvider.
+/// - serializeError: Error was encountered while serializing the transaction.
+/// - deserializeError: Error was encountered while deserializing transaction.
+/// - eosioNameError: Error was encountered in EosioName.
+/// - keyManagementError: Error was encountered in key management.
+/// - keySigningError: Error was encountered while signing with a key.
+/// - unexpectedError: There was an unexpected error.
 public enum EosioErrorCode: String, Codable {
 
+    /// Error was encountered while preparing the Transaction.
     case eosioTransactionError = "EosioTransactionError"
+    /// Error was encountered in RpcProvider.
     case rpcProviderError = "RpcProviderError"
+    /// Error was returned by getInfo() method.
     case getInfoError = "GetInfoError"
+    /// Error was encountered from getBlock() method.
     case getBlockError = "GetBlockError"
+    /// Error was returned by getRequiredKeys() method.
     case getRequiredKeysError = "GetRequiredKeysError"
+    /// Error was returned by getRawAbi() method.
     case getRawAbiError = "GetRawAbiError"
+    /// Error was encountered while pushing the transaction.
     case pushTransactionError = "PushTransactionError"
-    case signatureProviderError = "SignatureProviderErrorr"
+    /// Error was encountered in SignatureProvider.
+    case signatureProviderError = "SignatureProviderError"
+    /// Error was returned by getAvailableKeys() method.
     case getAvailableKeysError = "GetAvailableKeysError"
+    /// Error was encountered while signing the transaction.
     case signTransactionError = "SignTransactionError"
+    /// Error was encountered in AbiProvider.
     case abiProviderError = "AbiProviderError"
+    /// Error was returned by getAbi() method.
     case getAbiError = "GetAbiError"
+    /// Error was encountered in SerializationProvider.
     case serializationProviderError = "SerializationProviderError"
+    /// Error was encountered while serializing the transaction.
     case serializeError = "SerializeError"
+    /// Error was encountered while deserializing transaction.
     case deserializeError = "DeserializeError"
 
-    // non provider errors (added as these are encoundered in Eosio Extensions and Foundation)
+    // Non-provider errors (added as these are encountered in Eosio Extensions and Foundation).
+
+    /// Error was encountered in EosioName.
     case eosioNameError = "EosioNameError"
+    /// Error was encountered in key management.
     case keyManagementError = "KeyManagementError"
+    /// Error was encountered while signing with a key.
     case keySigningError = "KeySigningError"
 
-    // general catch all
+    // General catch all.
+
+    /// There was an unexpected error.
     case unexpectedError = "UnexpectedError"
 }
 
+/// An error for EOSIO SDK for Swift libraries containing an error code, reason, and the original error.
 open class EosioError: Error, CustomStringConvertible, Codable {
 
+    /// An `EosioErrorCode`.
     public var errorCode: EosioErrorCode
+    /// The reason for the error as a human-readable string.
     public var reason: String
+    /// The original error.
     public var originalError: NSError?
 
     enum CodingKeys: String, CodingKey {
@@ -68,6 +114,7 @@ open class EosioError: Error, CustomStringConvertible, Codable {
 
     }
 
+    /// Descriptions for the various `EosioErrorCode` members.
     public var description: String {
 
         switch self.errorCode {
@@ -113,6 +160,12 @@ open class EosioError: Error, CustomStringConvertible, Codable {
 
     }
 
+    /// Initialize an `EosioError`.
+    ///
+    /// - Parameters:
+    ///   - errorCode: An `EosioErrorCode`.
+    ///   - reason: The reason for the error as a human-readable string.
+    ///   - originalError: The original error.
     public init (_ errorCode: EosioErrorCode, reason: String, originalError: NSError? = nil) {
         self.errorCode = errorCode
         self.reason = reason
@@ -122,14 +175,15 @@ open class EosioError: Error, CustomStringConvertible, Codable {
 
 extension EosioError: LocalizedError {
 
+    /// Returns an error description.
     public var errorDescription: String? {
         return "\(self.errorCode.rawValue): \(self.reason)"
-
     }
 }
 
 public extension Error {
 
+    /// Returns an `EosioError` unexpected error for the given Error.
     var eosioError: EosioError {
 
         if let eosioError = self as? EosioError {

--- a/EosioSwift/Foundation/EosioResult.swift
+++ b/EosioSwift/Foundation/EosioResult.swift
@@ -8,9 +8,14 @@
 
 import Foundation
 
-// Used to provide typed results in closure returns so that there won't be any `nil` return states to test for.
+/// Provides typed results in closure returns so that there won't be any `nil` return states to test for.
+///
+/// - success: The success return state.
+/// - failure: The failure return state.
 public enum EosioResult<Success, Failure: Error> {
+    /// The success return state.
     case success(Success)
+    /// The failure return state.
     case failure(Failure)
 
     init?(success: Success?, failure: Failure?) {


### PR DESCRIPTION
See https://github.com/realm/jazzy/issues/660 for why the docs have to be in two places for the enum members. Kinds of sad, but hey.