### PR TITLE
Add docs for SigProvProt, SerProvProt, KeySigExt.

### DIFF
--- a/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
+++ b/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
@@ -636,7 +636,6 @@ public typealias EosioRpcTableByScopeResponse = RawResponse
 public typealias EosioRpcTableRowsResponse = RawResponse
 
 
-
 /* History Endpoints */
 
 /// Response type for the `get_actions` RPC endpoint.

--- a/EosioSwift/EosioSerializationProviderProtocol/EosioSerializationProviderProtocol.swift
+++ b/EosioSwift/EosioSerializationProviderProtocol/EosioSerializationProviderProtocol.swift
@@ -8,17 +8,72 @@
 
 import Foundation
 
+/// The protocol to which serialization provider implementations must conform.
+/// Serialization providers are responsible for ABI-driven transaction and action
+/// serialization and deserialization between JSON and binary data representations.
 public protocol EosioSerializationProviderProtocol {
+    /// Used to hold errors.
     var error: String? { get }
 
+    /// Initializer for the `EosioSerializationProviderProtocol`.
     init()
 
+    /// The method signature for general serialization requests to conforming serialization providers.
+    /// Carries out JSON to binary conversion using ABIs.
+
+    ///
+    /// - Parameters:
+    ///   - contract: An optional `String` representing contract name for the serialize action lookup for this conversion.
+    ///   - name: An optional `String` representing an action name that is used in conjunction with contract (above) to derive the serialize type name.
+    ///   - type: An optional `String` representing the type name for the action lookup for this serialize conversion.
+    ///   - json: The JSON data `String` to serialize to binary.
+    ///   - abi: A `String` representation of the ABI to use for conversion.
+    /// - Returns: A `String` of binary serialized data.
+    /// - Throws: If the data cannot be serialized for any reason.
     func serialize(contract: String?, name: String, type: String?, json: String, abi: String) throws  -> String
+
+    /// The method signature for general deserialization requests to conforming serialization providers.
+    /// Carries out binary to JSON conversion using ABIs.
+    ///
+    /// - Parameters:
+    ///   - contract: An optional `String` representing contract name for the deserialize action lookup for this conversion.
+    ///   - name: An optional `String` representing an action name that is used in conjunction with contract (above) to derive the deserialize type name.
+    ///   - type: An optional `String` representing the type name for the action lookup for this deserialize conversion.
+    ///   - hex: The binary data `String` to deserialize to a JSON String.
+    ///   - abi: A `String` representation of the ABI to use for conversion.
+    /// - Returns: A `String` of JSON data.
+    /// - Throws: If the data cannot be deserialized for any reason.
     func deserialize(contract: String?, name: String, type: String?, hex: String, abi: String) throws  -> String
 
+    /// The method signature for transaction serialization requests to conforming serialization providers.
+    /// Convert JSON Transaction data representation to binary `String` representation of Transaction data.
+    ///
+    /// - Parameter json: The JSON representation of Transaction data to serialize.
+    /// - Returns: A binary `String` representation of Transaction data.
+    /// - Throws: If the data cannot be serialized for any reason.
     func serializeTransaction(json: String) throws  -> String
+
+    /// The method signature for transaction deserialization requests to conforming serialization providers.
+    /// Converts a binary `String` representation of Transaction data to JSON `String` of Transaction data.
+    ///
+    /// - Parameter hex: The binary Transaction data `String` to deserialize.
+    /// - Returns: A `String` of JSON Transaction data.
+    /// - Throws: If the data cannot be deserialized for any reason.
     func deserializeTransaction(hex: String) throws  -> String
 
+    /// The method signature for ABI serialization requests to conforming serialization providers.
+    /// Convert JSON ABI to a `String` binary representation of data.
+    ///
+    /// - Parameter json: The JSON data `String` to serialize.
+    /// - Returns: A `String` representation of binary data.
+    /// - Throws: If the data cannot be serialized for any reason.
     func serializeAbi(json: String) throws  -> String
+
+    /// The method signature for ABI deserialization requests to conforming serialization providers.
+    /// Converts a binary `String` hex representation of an ABI to a JSON `String`.
+    ///
+    /// - Parameter hex: The binary data `String` to deserialize.
+    /// - Returns: A `String` of JSON data.
+    /// - Throws: If the data cannot be deserialized for any reason.
     func deserializeAbi(hex: String) throws  -> String
 }

--- a/EosioSwift/EosioSignatureProviderProtocol/EosioSignatureProviderProtocol.swift
+++ b/EosioSwift/EosioSignatureProviderProtocol/EosioSignatureProviderProtocol.swift
@@ -8,53 +8,84 @@
 
 import Foundation
 
+/// The transaction and related information structure sent to a signature provider for signing.
 public struct EosioTransactionSignatureRequest: Codable {
+    /// The serialized transaction as `Data`.
     public var serializedTransaction = Data()
+    /// The chain ID as a `String`.
     public var chainId = ""
+    /// An array of public keys identifying the private keys with which the transaction should be signed.
     public var publicKeys = [String]()
+    /// An array of `BinaryAbi`s sent along so that signature providers can display transaction information to the user.
     public var abis = [BinaryAbi]()
+    /// Should the signature provider be allowed to modify the transaction? E.g., adding an assert action. Defaults to `true`.
     public var isModificationAllowed = true
 
+    /// The structure for `BinaryAbi`s.
     public struct BinaryAbi: Codable {
+        /// The account name for the contract, as a `String`.
         public var accountName = ""
+        /// The binary representation of the ABI as a `String`.
         public var abi = ""
+        /// Initializer for the `BinaryAbi`.
         public init() { }
     }
 
+    /// Initializer for the `EosioTransactionSignatureRequest`.
     public init() { }
 }
 
+/// The structure for the response from a signature provider to an `EosioTransactionSignatureRequest`.
 public struct EosioTransactionSignatureResponse: Codable {
+    /// The signed transaction, as a `SignedTransaction`.
     public var signedTransaction: SignedTransaction?
+    /// An optional error.
     public var error: EosioError?
 
+    /// The structure for a `SignedTransaction`.
     public struct SignedTransaction: Codable {
+        /// The serialized transaction, as `Data`. This may be different the transaction requested if the transaction was modified by the signature provider.
         public var serializedTransaction = Data()
+        /// An array of signatures as `String`s.
         public var signatures = [String]()
+        /// Initializer for the `SignedTransaction`.
         public init() { }
     }
 
+    /// Initializer for the `EosioTransactionSignatureResponse`.
     public init() { }
 
+    /// Initializer for the `EosioTransactionSignatureResponse` when it contains an error.
+    ///
+    /// - Parameter error: The error as an `EosioError`.
     public init(error: EosioError) {
         self.error = error
     }
-
 }
 
+/// The structure for the response from a signature provider when asked what keys are available for signing.
 public struct EosioAvailableKeysResponse: Codable {
+    /// The keys as `String`s.
     public var keys: [String]?
+    /// An optional error.
     public var error: EosioError?
 
+    /// Initializer for the `EosioAvailableKeysResponse`.
     public init() { }
 }
 
+/// The protocol to which signature provider implementations must conform.
 public protocol EosioSignatureProviderProtocol {
 
-    // Sign transaction
+    /// The method signature for transaction signing requests to conforming signature providers.
+    ///
+    /// - Parameters:
+    ///   - request: The request as an `EosioTransactionSignatureRequest`.
+    ///   - completion: The completion that the signature provider implementation will call in response.
     func signTransaction(request: EosioTransactionSignatureRequest, completion: @escaping (EosioTransactionSignatureResponse) -> Void)
 
-    // Get available keys
+    /// The method signature for public key requests to conforming signature providers.
+    ///
+    /// - Parameter completion: The method signature for key requests to conforming signature providers.
     func getAvailableKeys(completion: @escaping (EosioAvailableKeysResponse) -> Void)
-
 }

--- a/EosioSwift/Extensions/EosioKeySignatureExtensions.swift
+++ b/EosioSwift/Extensions/EosioKeySignatureExtensions.swift
@@ -48,7 +48,7 @@ public extension Data {
         return self + hash.prefix(4)
     }
 
-    // Compresses a public key.
+    /// Compresses a public key.
     var toCompressedPublicKey: Data? {
         guard self.count == 65 else { return nil }
         let uncompressedKey = self


### PR DESCRIPTION
#147 

Adds/improves inline code documentation for:

* `EosioSerializationProviderProtocol.swift`
* `EosioSignatureProviderProtocol.swift`
* `EosioKeySignatureExtensions.swift`