### PR TITLE
Eosio rpc account response structure update

### DIFF
--- a/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
+++ b/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
@@ -267,11 +267,11 @@ public struct PermissionLevel: Decodable {
 /// Response type for `permission_level_weight in RPC endpoint responses.
 public struct PermissionLevelWeight: Decodable {
     public var weight: EosioUInt64
-    public var accounts: [PermissionLevel]
+    public var permission: PermissionLevel
 
     enum CodingKeys: String, CodingKey {
         case weight
-        case accounts
+        case permission
     }
 }
 
@@ -291,11 +291,13 @@ public struct Authority: Decodable {
     public var threshold: EosioUInt64
     public var keys: [KeyWeight]
     public var waits: [WaitWeight]
+    public var accounts: [PermissionLevelWeight]
 
     enum CodingKeys: String, CodingKey {
         case threshold
         case keys
         case waits
+        case accounts
     }
 }
 
@@ -303,10 +305,12 @@ public struct Authority: Decodable {
 public struct Permission: Decodable {
     public var permName: String
     public var parent: String
+    public var requiredAuth: Authority
 
     enum CodingKeys: String, CodingKey {
         case permName = "perm_name"
         case parent
+        case requiredAuth = "required_auth"
     }
 }
 

--- a/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
+++ b/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
@@ -445,6 +445,22 @@ class RpcProviderEndpointPromiseTests: XCTestCase {
             XCTAssertNotNil(eosioRpcAccountResponse)
             XCTAssert(eosioRpcAccountResponse.accountName == "cryptkeeper")
             XCTAssert(eosioRpcAccountResponse.ramQuota.value == 13639863)
+            let permissions = eosioRpcAccountResponse.permissions
+            XCTAssertNotNil(permissions)
+            guard let activePermission = permissions.filter({$0.permName == "active"}).first else {
+                return XCTFail("Cannot find Active permission in permissions structure of the account")
+            }
+            XCTAssert(activePermission.parent == "owner")
+            guard let keysAndWeight = activePermission.requiredAuth.keys.first else {
+                return XCTFail("Cannot find key in keys structure of the account")
+            }
+            XCTAssert(keysAndWeight.key == "EOS5j67P1W2RyBXAL8sNzYcDLox3yLpxyrxgkYy1xsXzVCvzbYpba")
+            guard let firstPermission = activePermission.requiredAuth.accounts.first else {
+                return XCTFail("Can't find permission in keys structure of the account")
+            }
+            XCTAssert(firstPermission.permission.actor == "eosaccount1")
+            XCTAssert(firstPermission.permission.permission == "active")
+            XCTAssert(activePermission.requiredAuth.waits.first?.waitSec.value == 259200)
             XCTAssertNotNil(eosioRpcAccountResponse.totalResources)
             if let dict = eosioRpcAccountResponse.totalResources {
                 if let owner = dict["owner"] as? String {

--- a/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
+++ b/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
@@ -164,6 +164,22 @@ class RpcProviderExtensionEndpointTests: XCTestCase {
                 XCTAssertNotNil(eosioRpcAccountResponse)
                 XCTAssert(eosioRpcAccountResponse.accountName == "cryptkeeper")
                 XCTAssert(eosioRpcAccountResponse.ramQuota.value == 13639863)
+                let permissions = eosioRpcAccountResponse.permissions
+                XCTAssertNotNil(permissions)
+                guard let activePermission = permissions.filter({$0.permName == "active"}).first else {
+                    return XCTFail("Cannot find Active permission in permissions structure of the account")
+                }
+                XCTAssert(activePermission.parent == "owner")
+                guard let keysAndWeight = activePermission.requiredAuth.keys.first else {
+                    return XCTFail("Cannot find key in keys structure of the account")
+                }
+                XCTAssert(keysAndWeight.key == "EOS5j67P1W2RyBXAL8sNzYcDLox3yLpxyrxgkYy1xsXzVCvzbYpba")
+                guard let firstPermission = activePermission.requiredAuth.accounts.first else {
+                    return XCTFail("Can't find permission in keys structure of the account")
+                }
+                XCTAssert(firstPermission.permission.actor == "eosaccount1")
+                XCTAssert(firstPermission.permission.permission == "active")
+                XCTAssert(activePermission.requiredAuth.waits.first?.waitSec.value == 259200)
                 XCTAssertNotNil(eosioRpcAccountResponse.totalResources)
                 if let dict = eosioRpcAccountResponse.totalResources {
                     if let owner = dict["owner"] as? String {

--- a/EosioSwiftTests/RpcTestConstants.swift
+++ b/EosioSwiftTests/RpcTestConstants.swift
@@ -609,8 +609,25 @@ public class RpcTestConstants {
                         "weight": 1
                     }
                 ],
-                "accounts": [],
-                "waits": []
+                "accounts": [
+                      {
+                        "permission": {
+                          "actor": "eosaccount1",
+                          "permission": "active"
+                        },
+                        "weight": 1
+                      },
+                ],
+                "waits": [
+                    {
+                        "wait_sec": 259200,
+                        "weight": 1
+                    },
+                    {
+                        "wait_sec": 604800,
+                        "weight": 2
+                    }
+                ]
             }
         },
         {


### PR DESCRIPTION
- Updated `EosioRpcAccountResponse` object that maps `get_account` RPC response
- Updated tests