### PR TITLE
Swift Package Manager support

### DIFF
--- a/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
+++ b/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import PromiseKit
+import PMKFoundation
 
 /// Default RPC Provider implementation. Conforms to `EosioRpcProviderProtocol`.
 /// RPC Reference: https://developers.eos.io/eosio-nodeos/reference

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -9,7 +9,13 @@
 import Foundation
 import XCTest
 @testable import EosioSwift
+
+#if canImport(OHHTTPStubs)
 import OHHTTPStubs
+#elseif canImport(OHHTTPStubsSwift)
+import OHHTTPStubsCore
+import OHHTTPStubsSwift
+#endif
 
 class EosioRpcProviderTests: XCTestCase {
 

--- a/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
+++ b/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
@@ -9,7 +9,14 @@
 import XCTest
 @testable import EosioSwift
 import PromiseKit
+
+#if canImport(OHHTTPStubs)
 import OHHTTPStubs
+#elseif canImport(OHHTTPStubsSwift)
+import OHHTTPStubsCore
+import OHHTTPStubsSwift
+#endif
+
 
 class RpcProviderEndpointPromiseTests: XCTestCase {
     var rpcProvider: EosioRpcProvider?

--- a/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
+++ b/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
@@ -8,7 +8,14 @@
 
 import XCTest
 @testable import EosioSwift
+
+#if canImport(OHHTTPStubs)
 import OHHTTPStubs
+#elseif canImport(OHHTTPStubsSwift)
+import OHHTTPStubsCore
+import OHHTTPStubsSwift
+#endif
+
 
 class RpcProviderExtensionEndpointTests: XCTestCase {
 

--- a/EosioSwiftTests/RpcTestConstants.swift
+++ b/EosioSwiftTests/RpcTestConstants.swift
@@ -8,7 +8,14 @@
 
 import Foundation
 import EosioSwift
+
+#if canImport(OHHTTPStubs)
 import OHHTTPStubs
+#elseif canImport(OHHTTPStubsSwift)
+import OHHTTPStubsCore
+import OHHTTPStubsSwift
+#endif
+
 
 // swiftlint:disable line_length
 public class RpcTestConstants {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "BigInt",
+        "repositoryURL": "https://github.com/attaswift/BigInt",
+        "state": {
+          "branch": null,
+          "revision": "19f5e8a48be155e34abb98a2bcf4a343316f0343",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "package": "PMKFoundation",
+        "repositoryURL": "https://github.com/PromiseKit/Foundation.git",
+        "state": {
+          "branch": null,
+          "revision": "ee06d95342a5007de2fffd898f4f35de026842ac",
+          "version": "3.3.3"
+        }
+      },
+      {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
+        "state": {
+          "branch": "feature/spm-support",
+          "revision": "fda9902f8c5c4170c6914d7dc845174e8c75bf92",
+          "version": null
+        }
+      },
+      {
+        "package": "PromiseKit",
+        "repositoryURL": "https://github.com/mxcl/PromiseKit",
+        "state": {
+          "branch": null,
+          "revision": "4d8d1287d2e50c53a9f8430ffe88925292838c57",
+          "version": "6.11.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "EosioSwift",
+    platforms: [
+       .macOS(.v10_13), .iOS(.v12),
+    ],
+    products: [
+        .library(
+            name: "EosioSwift",
+            targets: ["EosioSwift"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/attaswift/BigInt", from: "5.0.0"),
+        .package(url: "https://github.com/mxcl/PromiseKit", from: "6.8.0"),
+        .package(url: "https://github.com/PromiseKit/Foundation.git", from: "3.0.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .branch("feature/spm-support")),
+    ],
+    targets: [
+        .target(
+            name: "EosioSwift",
+            dependencies: ["BigInt", "PromiseKit", "PMKFoundation"],
+            path: "EosioSwift"),
+        .testTarget(
+            name: "EosioSwiftTests",
+            dependencies: ["EosioSwift", "OHHTTPStubsSwift"],
+            path: "EosioSwiftTests"),
+    ]
+)


### PR DESCRIPTION
This pull request adds support for installing EosioSwift via the [Swift Package Manager](https://swift.org/package-manager/).

Tests passing with `swift test` on MacOS 10.14.6