### PR TITLE
Added support for requesting a block by Id.

### DIFF
--- a/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
@@ -52,12 +52,28 @@ public struct EosioRpcPushTransactionRequest: Codable {
 /// Request struct for requests to `v1/chain/get_block`.
 /// To be compatible with EOSIO SDK for Swift, RPC endpoints must, at a minimum, accept these parameters.
 public struct EosioRpcBlockRequest: Codable {
+    enum CodingKeys: String, CodingKey {
+        case blockNumOrIdString = "block_num_or_id"
+    }
     /// The number or ID of the block you are fetching.
-    public var blockNumOrId: UInt64
-
+    @available(*, deprecated, message: "Please use blockNumOrIdString instead.")
+    public var blockNumOrId: UInt64 {
+        get {
+            return UInt64(blockNumOrIdString) ?? 0
+        }
+        set {
+            blockNumOrIdString = String(newValue)
+        }
+    }
+    /// The number or ID of the block you are fetching.
+    public var blockNumOrIdString: String
     /// Initialize an `EosioRpcBlockRequest`.
+    @available(*, deprecated, message: "Please use a String for blockNumOrId instead.")
     public init(blockNumOrId: UInt64 = 1) {
-        self.blockNumOrId = blockNumOrId
+        self.blockNumOrIdString = String(blockNumOrId)
+    }
+    public init(blockNumOrId: String) {
+        self.blockNumOrIdString = blockNumOrId
     }
 }
 

--- a/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
@@ -67,10 +67,11 @@ public struct EosioRpcBlockRequest: Codable {
     }
     /// The number or ID of the block you are fetching.
     public var blockNumberOrId: String
-    /// Initialize an `EosioRpcBlockRequest`.
+    /// Initialize an `EosioRpcBlockRequest` with a block number.
     public init(blockNumOrId: UInt64 = 1) {
         self.blockNumberOrId = String(blockNumOrId)
     }
+    /// Initialize an `EosioRpcBlockRequest` with a block number or id.
     public init(blockNumOrId: String) {
         self.blockNumberOrId = blockNumOrId
     }

--- a/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
@@ -68,6 +68,7 @@ public struct EosioRpcBlockRequest: Codable {
     /// The number or ID of the block you are fetching.
     public var blockNumberOrId: String
     /// Initialize an `EosioRpcBlockRequest`.
+    @available(*, deprecated, message: "Please use a String for blockNumOrId instead.")
     public init(blockNumOrId: UInt64 = 1) {
         self.blockNumberOrId = String(blockNumOrId)
     }

--- a/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
@@ -68,7 +68,6 @@ public struct EosioRpcBlockRequest: Codable {
     /// The number or ID of the block you are fetching.
     public var blockNumberOrId: String
     /// Initialize an `EosioRpcBlockRequest`.
-    @available(*, deprecated, message: "Please use a String for blockNumOrId instead.")
     public init(blockNumOrId: UInt64 = 1) {
         self.blockNumberOrId = String(blockNumOrId)
     }

--- a/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
+++ b/EosioSwift/EosioRpcProviderProtocol/RequestModels/RequestModels.swift
@@ -53,27 +53,26 @@ public struct EosioRpcPushTransactionRequest: Codable {
 /// To be compatible with EOSIO SDK for Swift, RPC endpoints must, at a minimum, accept these parameters.
 public struct EosioRpcBlockRequest: Codable {
     enum CodingKeys: String, CodingKey {
-        case blockNumOrIdString = "block_num_or_id"
+        case blockNumberOrId = "block_num_or_id"
     }
     /// The number or ID of the block you are fetching.
-    @available(*, deprecated, message: "Please use blockNumOrIdString instead.")
+    @available(*, deprecated, message: "Please use blockNumberOrId instead.")
     public var blockNumOrId: UInt64 {
         get {
-            return UInt64(blockNumOrIdString) ?? 0
+            return UInt64(blockNumberOrId) ?? 0
         }
         set {
-            blockNumOrIdString = String(newValue)
+            blockNumberOrId = String(newValue)
         }
     }
     /// The number or ID of the block you are fetching.
-    public var blockNumOrIdString: String
+    public var blockNumberOrId: String
     /// Initialize an `EosioRpcBlockRequest`.
-    @available(*, deprecated, message: "Please use a String for blockNumOrId instead.")
     public init(blockNumOrId: UInt64 = 1) {
-        self.blockNumOrIdString = String(blockNumOrId)
+        self.blockNumberOrId = String(blockNumOrId)
     }
     public init(blockNumOrId: String) {
-        self.blockNumOrIdString = blockNumOrId
+        self.blockNumberOrId = blockNumOrId
     }
 }
 

--- a/EosioSwift/EosioTransaction/EosioTransaction.swift
+++ b/EosioSwift/EosioTransaction/EosioTransaction.swift
@@ -428,7 +428,7 @@ public class EosioTransaction: Codable {
             return completion(.failure(EosioError(.eosioTransactionError, reason: "No rpc provider available")))
         }
 
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: String(blockNum))
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: blockNum)
 
         rpcProvider.getBlock(requestParameters: requestParameters, completion: { [weak self] (blockResponse) in
             guard let strongSelf = self else {

--- a/EosioSwift/EosioTransaction/EosioTransaction.swift
+++ b/EosioSwift/EosioTransaction/EosioTransaction.swift
@@ -428,7 +428,7 @@ public class EosioTransaction: Codable {
             return completion(.failure(EosioError(.eosioTransactionError, reason: "No rpc provider available")))
         }
 
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: blockNum)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: String(blockNum))
 
         rpcProvider.getBlock(requestParameters: requestParameters, completion: { [weak self] (blockResponse) in
             guard let strongSelf = self else {

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -345,6 +345,34 @@ class EosioRpcProviderTests: XCTestCase {
         wait(for: [expect], timeout: 30)
     }
 
+    /// Test getBlock() protocol implementation with using a block id.
+    func testGetBlockById() {
+        var callCount = 1
+        (stub(condition: isHost("localhost")) { request in
+            let retVal = RpcTestConstants.getHHTTPStubsResponse(callCount: callCount, urlRelativePath: request.url?.relativePath)
+            callCount += 1
+            return retVal
+        }).name = "Get Block stub"
+        let expect = expectation(description: "testGetBlock")
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+        rpcProvider.getBlock(requestParameters: requestParameters) { response in
+            switch response {
+            case .success(let blockResponse):
+                guard let rpcBlockResponse = blockResponse as? EosioRpcBlockResponse else {
+                    return XCTFail("Failed to convert rpc response")
+                }
+                XCTAssertTrue(rpcBlockResponse.blockNum.value == 25260032)
+                XCTAssertTrue(rpcBlockResponse.refBlockPrefix.value == 2249927103)
+                XCTAssertTrue(rpcBlockResponse.id == "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+            case .failure(let err):
+                print(err.description)
+                XCTFail("Failed get_block attempt")
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 30)
+    }
+
     /// Test getBlock() extended structure implementation.
     func testGetExtendedBlock() {
         var callCount = 1

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -289,6 +289,34 @@ class EosioRpcProviderTests: XCTestCase {
         wait(for: [expect], timeout: 30)
     }
 
+    /// Test getBlock() protocol implementation with using an UInt64 block num.
+    func testGetBlockByNum() {
+        var callCount = 1
+        (stub(condition: isHost("localhost")) { request in
+            let retVal = RpcTestConstants.getHHTTPStubsResponse(callCount: callCount, urlRelativePath: request.url?.relativePath)
+            callCount += 1
+            return retVal
+        }).name = "Get Block stub"
+        let expect = expectation(description: "testGetBlock")
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        rpcProvider.getBlock(requestParameters: requestParameters) { response in
+            switch response {
+            case .success(let blockResponse):
+                guard let rpcBlockResponse = blockResponse as? EosioRpcBlockResponse else {
+                    return XCTFail("Failed to convert rpc response")
+                }
+                XCTAssertTrue(rpcBlockResponse.blockNum.value == 25260032)
+                XCTAssertTrue(rpcBlockResponse.refBlockPrefix.value == 2249927103)
+                XCTAssertTrue(rpcBlockResponse.id == "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+            case .failure(let err):
+                print(err.description)
+                XCTFail("Failed get_block attempt")
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 30)
+    }
+
     /// Test getBlock() protocol implementation with using a block id.
     func testGetBlockById() {
         var callCount = 1

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -289,6 +289,34 @@ class EosioRpcProviderTests: XCTestCase {
         wait(for: [expect], timeout: 30)
     }
 
+    /// Test getBlock() protocol implementation with using a block id.
+    func testGetBlockById() {
+        var callCount = 1
+        (stub(condition: isHost("localhost")) { request in
+            let retVal = RpcTestConstants.getHHTTPStubsResponse(callCount: callCount, urlRelativePath: request.url?.relativePath)
+            callCount += 1
+            return retVal
+        }).name = "Get Block stub"
+        let expect = expectation(description: "testGetBlock")
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+        rpcProvider.getBlock(requestParameters: requestParameters) { response in
+            switch response {
+            case .success(let blockResponse):
+                guard let rpcBlockResponse = blockResponse as? EosioRpcBlockResponse else {
+                    return XCTFail("Failed to convert rpc response")
+                }
+                XCTAssertTrue(rpcBlockResponse.blockNum.value == 25260032)
+                XCTAssertTrue(rpcBlockResponse.refBlockPrefix.value == 2249927103)
+                XCTAssertTrue(rpcBlockResponse.id == "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
+            case .failure(let err):
+                print(err.description)
+                XCTFail("Failed get_block attempt")
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 30)
+    }
+
     /// Test getBlock() extended structure implementation.
     func testGetExtendedBlock() {
         var callCount = 1

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -53,7 +53,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "Retry Http Status 418 Error stub"
         let expect = expectation(description: "test_rpcProvider_shouldNotRetryFor418HttpStatusError")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -88,7 +88,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "Retry Http Status 401 Error stub"
         let expect = expectation(description: "test_rpcProvider_shouldNotRetryFor401HttpStatusError")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -123,7 +123,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "Retry Http Status 500 Error stub"
         let expect = expectation(description: "test_rpcProvider_shouldNotRetryFor500HttpStatusError")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -158,7 +158,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "Retry Http Status Error stub"
         let expect = expectation(description: "test_rpcProvider_shouldRetryBeforeReturningHttpStatusError")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -193,7 +193,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "Bad Response Handled stub"
         let expect = expectation(description: "testBadResponseDataHandled")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -270,7 +270,7 @@ class EosioRpcProviderTests: XCTestCase {
             return retVal
         }).name = "Get Block stub"
         let expect = expectation(description: "testGetBlock")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -308,7 +308,7 @@ class EosioRpcProviderTests: XCTestCase {
         }).name = "Get Extended Block stub"
 
         let expect = expectation(description: "testGetBlockExtended")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -525,7 +525,7 @@ class EosioRpcProviderTests: XCTestCase {
 
         }).name = "testFullFailoverFatalError"
         let expect = expectation(description: "testFullFailoverFatalError")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -586,7 +586,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "testFailoverNextEndpointSuccess stub"
         let expect = expectation(description: "testFailoverNextEndpointSuccess")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):
@@ -667,7 +667,7 @@ class EosioRpcProviderTests: XCTestCase {
             }
         }).name = "testFailoverWithBadChainId stub"
         let expect = expectation(description: "testFailoverWithBadChainId")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
         rpcProvider.getBlock(requestParameters: requestParameters) { response in
             switch response {
             case .success(let blockResponse):

--- a/EosioSwiftTests/EosioRpcProviderTests.swift
+++ b/EosioSwiftTests/EosioRpcProviderTests.swift
@@ -345,34 +345,6 @@ class EosioRpcProviderTests: XCTestCase {
         wait(for: [expect], timeout: 30)
     }
 
-    /// Test getBlock() protocol implementation with using a block id.
-    func testGetBlockById() {
-        var callCount = 1
-        (stub(condition: isHost("localhost")) { request in
-            let retVal = RpcTestConstants.getHHTTPStubsResponse(callCount: callCount, urlRelativePath: request.url?.relativePath)
-            callCount += 1
-            return retVal
-        }).name = "Get Block stub"
-        let expect = expectation(description: "testGetBlock")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
-        rpcProvider.getBlock(requestParameters: requestParameters) { response in
-            switch response {
-            case .success(let blockResponse):
-                guard let rpcBlockResponse = blockResponse as? EosioRpcBlockResponse else {
-                    return XCTFail("Failed to convert rpc response")
-                }
-                XCTAssertTrue(rpcBlockResponse.blockNum.value == 25260032)
-                XCTAssertTrue(rpcBlockResponse.refBlockPrefix.value == 2249927103)
-                XCTAssertTrue(rpcBlockResponse.id == "0181700002e623f2bf291b86a10a5cec4caab4954d4231f31f050f4f86f26116")
-            case .failure(let err):
-                print(err.description)
-                XCTFail("Failed get_block attempt")
-            }
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 30)
-    }
-
     /// Test getBlock() extended structure implementation.
     func testGetExtendedBlock() {
         var callCount = 1

--- a/EosioSwiftTests/EosioTransactionTests.swift
+++ b/EosioSwiftTests/EosioTransactionTests.swift
@@ -90,7 +90,7 @@ class EosioTransactionTests: XCTestCase {
         }
 
         transaction.prepare { (_) in
-            XCTAssertEqual(self.rpcProvider.blockNumberRequested, blockNum)
+            XCTAssertEqual(self.rpcProvider.blockNumberRequested, String(blockNum))
         }
 
     }
@@ -104,7 +104,7 @@ class EosioTransactionTests: XCTestCase {
     func test_getBlockAndSetTapos_shouldCallGetBlockFunctionOfRPCProviderWithCorrectBlockNumber() {
         let blockNumber: UInt64 = 234
         transaction.getBlockAndSetTapos(blockNum: blockNumber) { (_) in
-            XCTAssertEqual(self.rpcProvider.blockNumberRequested, blockNumber)
+            XCTAssertEqual(self.rpcProvider.blockNumberRequested, String(blockNumber))
         }
     }
 
@@ -451,7 +451,7 @@ class RPCProviderMock: EosioRpcProviderProtocol {
 
     var getBlockCalled = false
     var getBlockReturnsFailure = false
-    var blockNumberRequested: UInt64!
+    var blockNumberRequested: String!
     let block = EosioRpcBlockResponse(
         timestamp: "timestatmp",
         producer: "producer",
@@ -470,7 +470,7 @@ class RPCProviderMock: EosioRpcProviderProtocol {
 
     func getBlock(requestParameters: EosioRpcBlockRequest, completion: @escaping (EosioResult<EosioRpcBlockResponseProtocol, EosioError>) -> Void) {
         getBlockCalled = true
-        blockNumberRequested = requestParameters.blockNumOrId
+        blockNumberRequested = requestParameters.blockNumOrIdString
         let result: EosioResult<EosioRpcBlockResponseProtocol, EosioError>
         if getBlockReturnsFailure {
             result = EosioResult.failure(EosioError(.getBlockError, reason: "Some reason"))

--- a/EosioSwiftTests/EosioTransactionTests.swift
+++ b/EosioSwiftTests/EosioTransactionTests.swift
@@ -470,7 +470,7 @@ class RPCProviderMock: EosioRpcProviderProtocol {
 
     func getBlock(requestParameters: EosioRpcBlockRequest, completion: @escaping (EosioResult<EosioRpcBlockResponseProtocol, EosioError>) -> Void) {
         getBlockCalled = true
-        blockNumberRequested = requestParameters.blockNumOrIdString
+        blockNumberRequested = requestParameters.blockNumberOrId
         let result: EosioResult<EosioRpcBlockResponseProtocol, EosioError>
         if getBlockReturnsFailure {
             result = EosioResult.failure(EosioError(.getBlockError, reason: "Some reason"))

--- a/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
+++ b/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
@@ -79,7 +79,7 @@ class RpcProviderEndpointPromiseTests: XCTestCase {
             return retVal
         }).name = "Get Block Stub"
         let expect = expectation(description: "testGetBlock")
-        let requestParameters = EosioRpcBlockRequest(blockNumOrId: 25260032)
+        let requestParameters = EosioRpcBlockRequest(blockNumOrId: "25260032")
 
         firstly {
             (rpcProvider?.getBlock(.promise, requestParameters: requestParameters))!
@@ -307,7 +307,7 @@ class RpcProviderEndpointPromiseTests: XCTestCase {
             return retVal
         }).name = "GetBlockHeaderState stub"
         let expect = expectation(description: "testGetBlockHeaderState")
-        let requestParameters = EosioRpcBlockHeaderStateRequest(blockNumOrId: 25260035)
+        let requestParameters = EosioRpcBlockHeaderStateRequest(blockNumOrId: "25260035")
 
         firstly {
             (rpcProvider?.getBlockHeaderState(.promise, requestParameters: requestParameters))!

--- a/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
+++ b/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
@@ -69,7 +69,7 @@ class RpcProviderExtensionEndpointTests: XCTestCase {
             return retVal
         }).name = "GetBlockHeaderState stub"
         let expect = expectation(description: "testGetBlockHeaderState")
-        let requestParameters = EosioRpcBlockHeaderStateRequest(blockNumOrId: 25260035)
+        let requestParameters = EosioRpcBlockHeaderStateRequest(blockNumOrId: "25260035")
         rpcProvider?.getBlockHeaderState(requestParameters: requestParameters) { response in
             switch response {
             case .success(let eosioRpcBlockHeaderStateResponse):

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - BigInt
     - OHHTTPStubs
     - PromiseKit
@@ -49,4 +49,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 1d10bec70f8d2560be35e67e47b034772bba25f7
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.3


### PR DESCRIPTION
Added `blockNumOrIdString` to `EosioRpcBlockRequest`.
Deprecated `UInt64` `blockNumOrId` since it doesn’t really support block ids since they are strings.

The `EosioRpcBlockRequest` `init` parameter was named `blockNumOrId` but it was of the type `UInt64` so you couldn't actually request a block by id.  In the RPC docs the parameter is defined as a string and can take either a block num or a block id.

This change deprecates requesting a block by `UInt64` and adds support for requesting a block by id or num using a `String` parameter.

The original `blockNumOrId` property is changed to be a computed property and to store and return the value of the new `blockNumOrIdString` property.

I'm not thrilled with the name of the new property `blockNumOrIdString` since the better name would really be the original name but that has to remain for backward compatibility.  I'm open to suggestions for a better name for the property.  Other options I can think of would be: `blockNumberOrId`, `blockNumOrBlockId`.