### PR TITLE
Remove inline traces property

### DIFF
--- a/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
+++ b/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
@@ -806,7 +806,6 @@ public struct EosioRpcActionsResponseActionTrace: Decodable, EosioRpcResponsePro
     public var producerBlockId: String?
     public var accountRamDeltas: [EosioRpcActionsResponseActionTrActDeltas]
     public var exception: [String: Any]?
-    public var inlineTrances: [EosioRpcActionsResponseActionTrace]
 
     enum CustomCodingKeys: String, CodingKey {
         case receipt
@@ -820,7 +819,6 @@ public struct EosioRpcActionsResponseActionTrace: Decodable, EosioRpcResponsePro
         case producerBlockId = "producer_block_id"
         case accountRamDeltas = "account_ram_deltas"
         case exception = "except"
-        case inlineTrances = "inline_traces"
     }
 
     public init(from decoder: Decoder) throws {
@@ -839,7 +837,6 @@ public struct EosioRpcActionsResponseActionTrace: Decodable, EosioRpcResponsePro
 
         let exceptionContainer = try? container.nestedContainer(keyedBy: DynamicKey.self, forKey: .exception)
         exception = exceptionContainer?.decodeDynamicKeyValues() ?? [String: Any]()
-        inlineTrances = try container.decode([EosioRpcActionsResponseActionTrace].self, forKey: .inlineTrances)
     }
 }
 

--- a/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
+++ b/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
@@ -778,17 +778,17 @@ public struct EosioRpcActionsResponseAction: Decodable, EosioRpcResponseProtocol
         case accountActionSequence = "account_action_seq"
         case blockNumber = "block_num"
         case blockTime = "block_time"
-        case actionTrance = "action_trace"
+        case actionTrace = "action_trace"
     }
 
     public init(from decoder: Decoder) throws {
-        let contanter = try decoder.container(keyedBy: CustomCodingKeys.self)
+        let container = try decoder.container(keyedBy: CustomCodingKeys.self)
 
-        globalActionSequence = try contanter.decode(EosioUInt64.self, forKey: .globalActionSequence)
-        accountActionSequence = try contanter.decode(Int32.self, forKey: .accountActionSequence)
-        blockNumber = try contanter.decode(UInt32.self, forKey: .blockNumber)
-        blockTime = try contanter.decode(String.self, forKey: .blockTime)
-        actionTrace = try contanter.decode(EosioRpcActionsResponseActionTrace.self, forKey: .actionTrance)
+        globalActionSequence = try container.decode(EosioUInt64.self, forKey: .globalActionSequence)
+        accountActionSequence = try container.decode(Int32.self, forKey: .accountActionSequence)
+        blockNumber = try container.decode(UInt32.self, forKey: .blockNumber)
+        blockTime = try container.decode(String.self, forKey: .blockTime)
+        actionTrace = try container.decode(EosioRpcActionsResponseActionTrace.self, forKey: .actionTrace)
     }
 }
 

--- a/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
+++ b/EosioSwiftTests/RpcProviderEndpointPromiseTests.swift
@@ -996,7 +996,6 @@ class RpcProviderEndpointPromiseTests: XCTestCase {
             XCTAssert($0.actions.first?.actionTrace.action.data["memo"] as? String == "l2sbjsdrfd.m")
             XCTAssert($0.actions.first?.actionTrace.action.hexData == "10826257e3ab38ad000000004800a739f3eef20b00000000044d4545544f4e450c6c3273626a736472666a2e6f")
             XCTAssert($0.actions.first?.actionTrace.accountRamDeltas.first?.delta.value == 472)
-            XCTAssert($0.actions.first?.actionTrace.inlineTrances.first?.receipt.actionDigest == "62021c2315d8245d0546180daf825d728a5564d2831e8b2d1f2d01309bf06b")
         }.catch {
             print($0)
             if unhappy {

--- a/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
+++ b/EosioSwiftTests/RpcProviderExtensionEndpointTests.swift
@@ -581,7 +581,6 @@ class RpcProviderExtensionEndpointTests: XCTestCase {
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.action.data["memo"] as? String == "l2sbjsdrfd.m")
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.action.hexData == "10826257e3ab38ad000000004800a739f3eef20b00000000044d4545544f4e450c6c3273626a736472666a2e6f")
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.accountRamDeltas.first?.delta.value == 472)
-                XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.inlineTrances.first?.receipt.actionDigest == "62021c2315d8245d0546180daf825d728a5564d2831e8b2d1f2d01309bf06b")
             case .failure(let err):
                 print(err.description)
                 XCTFail("Failed get_actions")
@@ -628,7 +627,6 @@ class RpcProviderExtensionEndpointTests: XCTestCase {
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.action.data["memo"] as? String == "l2sbjsdrfd.m")
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.action.hexData == "10826257e3ab38ad000000004800a739f3eef20b00000000044d4545544f4e450c6c3273626a736472666a2e6f")
                 XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.accountRamDeltas.first?.delta.value == -1)
-                XCTAssert(eosioRpcActionsResponse.actions.first?.actionTrace.inlineTrances.first?.receipt.actionDigest == "62021c2315d8245d0546180daf825d728a5564d2831e8b2d1f2d01309bf06b")
             case .failure(let err):
                 print(err.description)
                 XCTFail("Failed get_actions")

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - BigInt
     - OHHTTPStubs
     - PromiseKit
@@ -49,4 +49,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 1d10bec70f8d2560be35e67e47b034772bba25f7
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.3


### PR DESCRIPTION
The inlineTraces property of EosioRpcActionsResponseActionTrace was deprecated with the release of EOSIO 1.8. After discussions with the team, a decision was made to remove this interface as developers can dive into the raw response if they need trace data.
 
This resolves the issue raised by #219