### PR TITLE
Added setting of original error when creating an EosioError from an Error.

### DIFF
--- a/EosioSwift/Foundation/EosioError.swift
+++ b/EosioSwift/Foundation/EosioError.swift
@@ -197,7 +197,7 @@ public extension Error {
             return eosioError
         }
 
-        return EosioError(EosioErrorCode.unexpectedError, reason: self.localizedDescription)
+        return EosioError(EosioErrorCode.unexpectedError, reason: self.localizedDescription, originalError: self as NSError)
     }
 
 }


### PR DESCRIPTION
When using the extension on Error to create an EosioError it was not setting the original error.

https://github.com/EOSIO/eosio-swift/issues/227
