### PR TITLE
Allow to add and remove an authorization

### DIFF
--- a/EosioSwift/EosioTransaction/EosioTransactionAction.swift
+++ b/EosioSwift/EosioTransaction/EosioTransactionAction.swift
@@ -39,6 +39,23 @@ public extension EosioTransaction {
             return dataSerialized != nil
         }
 
+        /// Add an Authorization.
+        ///
+        /// - Parameters:
+        ///   - authorization: The Authorization to add.
+        ///   - at: An optional index at which to insert the Authorization. If not provided, the Authorization will be appended to the end of the authorization array.
+        public func add(authorization auth: Authorization, at: Int? = nil) {
+            authorization.insert(auth, at: at ?? authorization.count)
+        }
+
+        /// Remove an Authorization.
+        ///
+        /// - Parameters:
+        ///   - at: The position of the authorization to remove. index must be a valid index of the collection that is not equal to the collection’s end index
+        public func removeAuthorization(at: Int) -> Authorization? {
+            return authorization.remove(at: at)
+        }
+
         /// Coding keys
         enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
             case account

--- a/EosioSwiftTests/EosioTransactionActionTests.swift
+++ b/EosioSwiftTests/EosioTransactionActionTests.swift
@@ -115,6 +115,32 @@ class EosioTransactionActionTests: XCTestCase {
         XCTAssertTrue(action.dataHex == "00000000009012cd00000060d234cd3da0680600000000000453595300000000114772617373686f7070657220526f636b73")
     }
 
+    func testAddAuthorizationAtIndexShouldSucceed() {
+        guard let action = try? makeTransferActionWithEosioNames() else {
+            return XCTFail("Could not create an action")
+        }
+
+        guard let authorization = try? EosioTransaction.Action.Authorization(actor: "12character", permission: "12character") else {
+            return XCTFail("Could not create an authorization")
+        }
+
+        action.add(authorization: authorization, at: 0)
+        XCTAssertEqual(action.authorization.count, 2)
+        XCTAssertEqual(action.authorization[0], authorization)
+    }
+
+    func testRemoveAuthorizationAtIndexShouldSucceed() {
+        guard let action = try? makeTransferActionWithEosioNames() else {
+            return XCTFail("Could not create an action")
+        }
+
+        let authorization = action.authorization[0]
+        let removedAuthorization = action.removeAuthorization(at: 0)
+
+        XCTAssertEqual(action.authorization.count, 0)
+        XCTAssertEqual(authorization, removedAuthorization)
+    }
+
     ///////////////////////////////// convenience methods /////////////////////////////////
 
     struct Transfer: Codable {


### PR DESCRIPTION
This pull requests adds functionality allowing to add and remove an authorization.

**More context:**
At the moment it is not possible to modify authorizations, which makes virtually impossible to implement [ONLY_BILL_FIRST_AUTHORIZER](https://github.com/EOSIO/spec-repo/blob/master/esr_contract_pays.md) where the first authorizer (payer) may need to be added additionally to an already existing transaction. Nor it is possible to remove (replace) action with a modified one that would already contain the required authorization. This change fixes that.