### PR TITLE
Make action initializable with a dictionary data

### DIFF
--- a/EosioSwift/EosioTransaction/EosioTransactionAction.swift
+++ b/EosioSwift/EosioTransaction/EosioTransactionAction.swift
@@ -67,11 +67,36 @@ public extension EosioTransaction {
         ///   - authorization: Authorization (actor and permission).
         ///   - data: Action data (codable struct).
         /// - Throws: If the strings are not valid eosio names or data cannot be encoded.
-        public init(account: EosioName, name: EosioName, authorization: [Authorization], data: Encodable) throws {
+        public convenience init(account: EosioName, name: EosioName, authorization: [Authorization], data: Encodable) throws {
+            let dict = try data.toJsonString().jsonToDictionary()
+            self.init(account: account, name: name, authorization: authorization, data: dict)
+        }
+
+        /// Init Action struct with strings and a Dictionary for data. Strings will be used to init EosioNames.
+        ///
+        /// - Parameters:
+        ///   - account: Contract account name.
+        ///   - name: Contract action name.
+        ///   - authorization: Authorization (actor and permission).
+        ///   - data: Dictionary.
+        /// - Throws: If the strings are not valid EOSIO names or data cannot be encoded.
+        public convenience init(account: String, name: String, authorization: [Authorization], data: [String: Any]) throws {
+            try self.init(account: EosioName(account), name: EosioName(name), authorization: authorization, data: data)
+        }
+
+        /// Init Action struct with `EosioName`s and a Dictionary for data.
+        ///
+        /// - Parameters:
+        ///   - account: Contract account name.
+        ///   - name: Contract action name.
+        ///   - authorization: Authorization (actor and permission).
+        ///   - data: Dictionary.
+        /// - Throws: If the strings are not valid eosio names or data cannot be encoded.
+        public init(account: EosioName, name: EosioName, authorization: [Authorization], data: [String: Any]) {
             self.account = account
             self.name = name
             self.authorization = authorization
-            self.data = try data.toJsonString().jsonToDictionary()
+            self.data = data
         }
 
         /// Init Action struct with strings and serialized data. Strings will be used to init EosioNames.

--- a/EosioSwiftTests/EosioTransactionActionTests.swift
+++ b/EosioSwiftTests/EosioTransactionActionTests.swift
@@ -36,6 +36,10 @@ class EosioTransactionActionTests: XCTestCase {
         XCTAssertNotNil(try? makeTransferActionWithStrings())
     }
 
+    func testNewTransferActionWithDictionary() {
+        XCTAssertNotNil(try? makeTransferActionWithDictionary())
+    }
+
     func testNewTransferActionError() {
         do {
             try _ = makeTransferActionWithError()
@@ -202,6 +206,20 @@ class EosioTransactionActionTests: XCTestCase {
             ],
             dataSerialized: Data(hexString: "00000000009012cd00000060d234cd3da0680600000000000453595300000000114772617373686f7070657220526f636b73")!
         )
+        return action
+    }
+
+    func makeTransferActionWithDictionary() throws -> EosioTransaction.Action {
+        let action = try EosioTransaction.Action(
+            account: "eosio.token",
+            name: "transfer",
+            authorization: [EosioTransaction.Action.Authorization(
+                actor: "todd",
+                permission: "active")
+            ],
+            data: makeComplexData().toDictionary()!
+        )
+
         return action
     }
 


### PR DESCRIPTION
This pull request makes it possible to initialize an action with a dictionary data (`[String: Any]`) as opposed to just `Encodable` and `Data`.

1. In case of building an action that consists of a completely custom data that may not be known in advance (received from a SDK request for example) we can't have a struct already in place that would conform to `Encodable` as requested at the moment.

2. The only other option is to pass the data (Dictionary) as `dataSerialized`. The problem here however is that in order to do that we need to download the required (missing) abis (`transaction.retrieveMissingAbis`...) and serialize data ourselves (there is quite a lot to it). All of this, is however already being handled within the `EosioTransaction`. Wouldn't it simply make more sense then to allow passing in a dictionary (which is used inside anyway) and let the `EosioTransaction` take care of it instead of duplicating the exactly same code outside of the transaction...?

3. Last but not least, at the moment it is also difficult to copy (clone) action's data. Data are either accessible as `serialized` or as a `Dictionary<String, Any>` which once again, cannot be used to create a new action as the constructor only accepts `Encodable` (`[String: Any]` does not conform to it) or the already mentioned (serialized) `Data` 😐
