### PR TITLE
Fix EosioSignatureProviderProtocol default implementation extension to preserve compatibility

### DIFF
--- a/EosioSwift/EosioSignatureProviderProtocol/EosioSignatureProviderProtocol.swift
+++ b/EosioSwift/EosioSignatureProviderProtocol/EosioSignatureProviderProtocol.swift
@@ -91,8 +91,8 @@ public protocol EosioSignatureProviderProtocol {
     ///   - prompt: Prompt for biometric authentication, if required.
     ///   - completion: The completion that the signature provider implementation will call in response.
     func signTransaction(request: EosioTransactionSignatureRequest,
-                                prompt: String,
-                                completion: @escaping (EosioTransactionSignatureResponse) -> Void)
+                         prompt: String,
+                         completion: @escaping (EosioTransactionSignatureResponse) -> Void)
 
     /// The method signature for public key requests to conforming signature providers.
     ///
@@ -100,9 +100,10 @@ public protocol EosioSignatureProviderProtocol {
     func getAvailableKeys(completion: @escaping (EosioAvailableKeysResponse) -> Void)
 }
 
-extension EosioSignatureProviderProtocol {
+public extension EosioSignatureProviderProtocol {
     func signTransaction(request: EosioTransactionSignatureRequest,
-                                prompt: String,
-                                completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
+                         prompt: String,
+                         completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
+        self.signTransaction(request: request, completion: completion)
     }
 }

--- a/EosioSwiftTests/EosioTransactionTests.swift
+++ b/EosioSwiftTests/EosioTransactionTests.swift
@@ -566,12 +566,14 @@ class SignatureProviderMock: EosioSignatureProviderProtocol {
 
     var getAvailableKeysShouldReturnFailure = false
 
+    // The tests will run correctly without this implemented as well showing that
+    // the default implementation in the protocol is functioning properly.
     func signTransaction(request: EosioTransactionSignatureRequest,
                          prompt: String,
                          completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
         return self.signTransaction(request: request, completion: completion)
     }
-    
+
     func signTransaction(request: EosioTransactionSignatureRequest, completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
         var transactionSignatureResponse = EosioTransactionSignatureResponse()
 


### PR DESCRIPTION
Make extension for default implementation of the signTransaction method with the prompt public and have it call the required implementation without the prompt argument so that it really is optional for implementations like it was supposed to be.