### PR TITLE
Added combine publisher support for rpc provider and transaction.

### DIFF
--- a/EosioSwift.xcodeproj/project.pbxproj
+++ b/EosioSwift.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		BBAC7BCE225266A40035CDBC /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAC7BCD225266A40035CDBC /* DateExtensionTests.swift */; };
 		BBCA8F422241331C00B02372 /* EosioTransactionActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCA8F412241331C00B02372 /* EosioTransactionActionTests.swift */; };
 		D9EC085EBBCF1FFF1D2D012C /* Pods_EosioSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5835070C5F7998E17BF06017 /* Pods_EosioSwiftTests.framework */; };
+		E447C1192460C8A900FBA76A /* EosioRpcProviderEndpointsCombine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E447C1182460C8A900FBA76A /* EosioRpcProviderEndpointsCombine.swift */; };
+		E4D9E66B24620C12007F18D6 /* EosioTransactionCombine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D9E66A24620C12007F18D6 /* EosioTransactionCombine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,6 +146,8 @@
 		BBAC7BCD225266A40035CDBC /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		BBCA8F412241331C00B02372 /* EosioTransactionActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioTransactionActionTests.swift; sourceTree = "<group>"; };
 		D3E4478EE834B70DDF06A7FA /* Pods_EosioSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EosioSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E447C1182460C8A900FBA76A /* EosioRpcProviderEndpointsCombine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioRpcProviderEndpointsCombine.swift; sourceTree = "<group>"; };
+		E4D9E66A24620C12007F18D6 /* EosioTransactionCombine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EosioTransactionCombine.swift; sourceTree = "<group>"; };
 		F7404A6D5764E579E57E1897 /* Pods-EosioSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EosioSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-EosioSwiftTests/Pods-EosioSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -193,6 +197,7 @@
 				28FE03972209D44700CCC977 /* EosioTransaction.swift */,
 				2856028E22182EFA00642377 /* EosioTransactionAbis.swift */,
 				28FE03992209D4C100CCC977 /* EosioTransactionAction.swift */,
+				E4D9E66A24620C12007F18D6 /* EosioTransactionCombine.swift */,
 				BB6F2CFD22653012002C4150 /* EosioTransactionFactory.swift */,
 				B44461622267CE37002C77C9 /* EosioTransactionPromises.swift */,
 			);
@@ -211,9 +216,10 @@
 		3E298A4C226E0EF400B964B7 /* Endpoints */ = {
 			isa = PBXGroup;
 			children = (
-				3EE762A12268C48D00D8DC33 /* EosioRpcProviderEndpointsPromises.swift */,
 				3E298A4D226E0F2F00B964B7 /* EosioRpcProviderEndpointsCallbacks.swift */,
+				E447C1182460C8A900FBA76A /* EosioRpcProviderEndpointsCombine.swift */,
 				3E298A4F226E113700B964B7 /* EosioRpcProviderEndpointsForProtocol.swift */,
+				3EE762A12268C48D00D8DC33 /* EosioRpcProviderEndpointsPromises.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -592,6 +598,7 @@
 				B466F0962229DA870082DC4E /* EosioSerializationProviderProtocol.swift in Sources */,
 				8F6B04B922287A5300215CD0 /* ZAssert.swift in Sources */,
 				B4178067226E472E00084A6E /* DynamicKey.swift in Sources */,
+				E4D9E66B24620C12007F18D6 /* EosioTransactionCombine.swift in Sources */,
 				8F6B04C622287A9E00215CD0 /* ArrayExtensions.swift in Sources */,
 				28FE03982209D44700CCC977 /* EosioTransaction.swift in Sources */,
 				3E298A50226E113700B964B7 /* EosioRpcProviderEndpointsForProtocol.swift in Sources */,
@@ -602,6 +609,7 @@
 				BB6F2CFE22653012002C4150 /* EosioTransactionFactory.swift in Sources */,
 				8FD1C4C82257EADE005AE506 /* AllResponseProtocols.swift in Sources */,
 				B4892C6D221E0CAA0050FA72 /* RequestModels.swift in Sources */,
+				E447C1192460C8A900FBA76A /* EosioRpcProviderEndpointsCombine.swift in Sources */,
 				1FDD00412279F62000E59784 /* LinkedList.swift in Sources */,
 				28FE039A2209D4C100CCC977 /* EosioTransactionAction.swift in Sources */,
 				B42C0EFB2268F86200E7A28F /* ResolverExtensions.swift in Sources */,

--- a/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCombine.swift
+++ b/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCombine.swift
@@ -1,0 +1,258 @@
+//
+//  EosioRpcProviderEndpointsCombine.swift
+//  EosioSwift
+//  Created by Mark Johnson on 5/4/20
+//  Copyright (c) 2017-2020 block.one and its contributors. All rights reserved.
+//
+
+import Foundation
+#if canImport(Combine)
+  import Combine
+#endif
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension EosioRpcProvider {
+    /* Chain Endpoints */
+
+    /// Call `chain/get_account` and get a Publisher back. Fetch an account by account name.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcAccountRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcAccountResponse` or rejected with an `EosioError`.
+    public func getAccountPublisher(requestParameters: EosioRpcAccountRequest) -> AnyPublisher<EosioRpcAccountResponse, EosioError> {
+        return Future<EosioRpcAccountResponse, EosioError> { [weak self] promise in
+            self?.getAccount(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_block` and get a Publisher back. Get a block by block number or ID.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcBlockRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcBlockResponse` or rejected with an `EosioError`.
+    public func getBlockPublisher(requestParameters: EosioRpcBlockRequest) -> AnyPublisher<EosioRpcBlockResponse, EosioError> {
+        return Future<EosioRpcBlockResponse, EosioError> { [weak self] promise in
+            self?.getBlock(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_info` and get a Publisher back. Get information about the chain and node.
+    ///
+    /// - Returns: A Publisher fulfilled with an `EosioRpcInfoResponse` or rejected with an `EosioError`.
+    public func getInfoPublisher() -> AnyPublisher<EosioRpcInfoResponse, EosioError> {
+        return Future<EosioRpcInfoResponse, EosioError> { [weak self] promise in
+            self?.getInfo(completion: { promise($0.asResult) } as ((EosioResult<EosioRpcInfoResponse, EosioError>) -> Void))
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/push_transaction` and get a Publisher back. Push a transaction to the blockchain!
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcPushTransactionRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcTransactionResponse` or rejected with an `EosioError`.
+    public func pushTransactionPublisher(requestParameters: EosioRpcPushTransactionRequest) -> AnyPublisher<EosioRpcTransactionResponse, EosioError> {
+        return Future<EosioRpcTransactionResponse, EosioError> { [weak self] promise in
+            self?.pushTransaction(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/push_transactions` and get a Publisher back. Push multiple transactions to the chain.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcPushTransactionsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcPushTransactionsResponse` or rejected with an `EosioError`.
+    public func pushTransactionsPublisher(requestParameters: EosioRpcPushTransactionsRequest) -> AnyPublisher<EosioRpcPushTransactionsResponse, EosioError> {
+        return Future<EosioRpcPushTransactionsResponse, EosioError> { [weak self] promise in
+            self?.pushTransactions(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_block_header_state` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcBlockHeaderStateRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcBlockHeaderStateResponse` or rejected with an `EosioError`.
+    public func getBlockHeaderStatePublisher(requestParameters: EosioRpcBlockHeaderStateRequest) -> AnyPublisher<EosioRpcBlockHeaderStateResponse, EosioError> {
+        return Future<EosioRpcBlockHeaderStateResponse, EosioError> { [weak self] promise in
+            self?.getBlockHeaderState(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_abi` and get a Publisher back. Fetch an ABI by account/contract name.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcAbiRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcAbiResponse` or rejected with an `EosioError`.
+    public func getAbiPublisher(requestParameters: EosioRpcAbiRequest) -> AnyPublisher<EosioRpcAbiResponse, EosioError> {
+        return Future<EosioRpcAbiResponse, EosioError> { [weak self] promise in
+            self?.getAbi(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_currency_balance` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcCurrencyBalanceRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcCurrencyBalanceResponse` or rejected with an `EosioError`.
+    public func getCurrencyBalancePublisher(requestParameters: EosioRpcCurrencyBalanceRequest) -> AnyPublisher<EosioRpcCurrencyBalanceResponse, EosioError> {
+        return Future<EosioRpcCurrencyBalanceResponse, EosioError> { [weak self] promise in
+            self?.getCurrencyBalance(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_currency_stats` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcCurrencyStatsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcCurrencyStatsResponse` or rejected with an `EosioError`.
+    public func getCurrencyStatsPublisher(requestParameters: EosioRpcCurrencyStatsRequest) -> AnyPublisher<EosioRpcCurrencyStatsResponse, EosioError> {
+        return Future<EosioRpcCurrencyStatsResponse, EosioError> { [weak self] promise in
+            self?.getCurrencyStats(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_required_keys` and get a Publisher back. Pass in a transaction and an array of available keys. Get back the subset of those keys required for signing the transaction.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcRequiredKeysRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcRequiredKeysResponse` or rejected with an `EosioError`.
+    public func getRequiredKeysPublisher(requestParameters: EosioRpcRequiredKeysRequest) -> AnyPublisher<EosioRpcRequiredKeysResponse, EosioError> {
+        return Future<EosioRpcRequiredKeysResponse, EosioError> { [weak self] promise in
+            self?.getRequiredKeys(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_producers` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcProducersRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcProducersResponse` or rejected with an `EosioError`.
+    public func getProducersPublisher(requestParameters: EosioRpcProducersRequest) -> AnyPublisher<EosioRpcProducersResponse, EosioError> {
+        return Future<EosioRpcProducersResponse, EosioError> { [weak self] promise in
+            self?.getProducers(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_raw_code_and_abi` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcRawCodeAndAbiRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcRawCodeAndAbiResponse` or rejected with an `EosioError`.
+    public func getRawCodeAndAbiPublisher(requestParameters: EosioRpcRawCodeAndAbiRequest) -> AnyPublisher<EosioRpcRawCodeAndAbiResponse, EosioError> {
+        return Future<EosioRpcRawCodeAndAbiResponse, EosioError> { [weak self] promise in
+            self?.getRawCodeAndAbi(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_raw_code_and_abi` and get a Publisher back. Convenience method called with simple account name.
+    ///
+    /// - Parameters:
+    ///   - accountName: The account/contract name, as a String.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcRawCodeAndAbiResponse` or rejected with an `EosioError`.
+    public func getRawCodeAndAbiPublisher(accountName: String) -> AnyPublisher<EosioRpcRawCodeAndAbiResponse, EosioError> {
+        return Future<EosioRpcRawCodeAndAbiResponse, EosioError> { [weak self] promise in
+            self?.getRawCodeAndAbi(accountName: accountName, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_table_by_scope` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcTableByScopeRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcTableByScopeResponse` or rejected with an `EosioError`.
+    public func getTableByScopePublisher(requestParameters: EosioRpcTableByScopeRequest) -> AnyPublisher<EosioRpcTableByScopeResponse, EosioError> {
+        return Future<EosioRpcTableByScopeResponse, EosioError> { [weak self] promise in
+            self?.getTableByScope(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_table_rows` and get a Publisher back. Returns an object containing rows from the specified table.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcTableRowsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcTableRowsResponse` or rejected with an `EosioError`.
+    public func getTableRowsPublisher(requestParameters: EosioRpcTableRowsRequest) -> AnyPublisher<EosioRpcTableRowsResponse, EosioError> {
+        return Future<EosioRpcTableRowsResponse, EosioError> { [weak self] promise in
+            self?.getTableRows(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_code` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcCodeRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcCodeResponse` or rejected with an `EosioError`.
+    public func getCodePublisher(requestParameters: EosioRpcCodeRequest) -> AnyPublisher<EosioRpcCodeResponse, EosioError> {
+        return Future<EosioRpcCodeResponse, EosioError> { [weak self] promise in
+            self?.getCode(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_code` and geta Publisher back. Convenience method called with simple account name.
+    ///
+    /// - Parameters:
+    ///   - accountName: The account/contract name, as a String.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcCodeResponse` or rejected with an `EosioError`.
+    public func getCodePublisher(accountName: String) -> AnyPublisher<EosioRpcCodeResponse, EosioError> {
+        return Future<EosioRpcCodeResponse, EosioError> { [weak self] promise in
+            self?.getCode(accountName: accountName, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `chain/get_raw_abi` and get a Publisher back. Get a raw abi.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcRawAbiRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcRawAbiResponse` or rejected with an `EosioError`.
+    public func getRawAbiPublisher(requestParameters: EosioRpcRawAbiRequest) -> AnyPublisher<EosioRpcRawAbiResponse, EosioError> {
+        return Future<EosioRpcRawAbiResponse, EosioError> { [weak self] promise in
+            self?.getRawAbi(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /* History Endpoints */
+
+    /// Call `history/get_actions` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcHistoryActionsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcActionsResponse` or rejected with an `EosioError`.
+    public func getActionsPublisher(requestParameters: EosioRpcHistoryActionsRequest) -> AnyPublisher<EosioRpcActionsResponse, EosioError> {
+        return Future<EosioRpcActionsResponse, EosioError> { [weak self] promise in
+            self?.getActions(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `history/get_transaction` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcHistoryTransactionRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcGetTransactionResponse` or rejected with an `EosioError`.
+    public func getTransactionPublisher(requestParameters: EosioRpcHistoryTransactionRequest) -> AnyPublisher<EosioRpcGetTransactionResponse, EosioError> {
+        return Future<EosioRpcGetTransactionResponse, EosioError> { [weak self] promise in
+            self?.getTransaction(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `history/get_key_accounts` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcHistoryKeyAccountsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcKeyAccountsResponse` or rejected with an `EosioError`.
+    public func getKeyAccountsPublisher(requestParameters: EosioRpcHistoryKeyAccountsRequest) -> AnyPublisher<EosioRpcKeyAccountsResponse, EosioError> {
+        return Future<EosioRpcKeyAccountsResponse, EosioError> { [weak self] promise in
+            self?.getKeyAccounts(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Call `history/get_controlled_accounts` and get a Publisher back.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcHistoryControlledAccountsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcControlledAccountsResponse` or rejected with an `EosioError`.
+    public func getControlledAccountsPublisher(requestParameters: EosioRpcHistoryControlledAccountsRequest) -> AnyPublisher<EosioRpcControlledAccountsResponse, EosioError> {
+        return Future<EosioRpcControlledAccountsResponse, EosioError> { [weak self] promise in
+            self?.getControlledAccounts(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+}

--- a/EosioSwift/EosioTransaction/EosioTransactionCombine.swift
+++ b/EosioSwift/EosioTransaction/EosioTransactionCombine.swift
@@ -1,0 +1,85 @@
+//
+//  EosioTransactionCombine.swift
+//  EosioSwift
+
+//  Created by Mark Johnson on 5/5/20
+//  Copyright (c) 2017-2020 block.one and its contributors. All rights reserved.
+//
+
+import Foundation
+#if canImport(Combine)
+  import Combine
+#endif
+
+// MARK: - `EosioTransaction` methods returning Publishers.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension EosioTransaction {
+    /// Publisher based method for signing a transaction and then broadcasting it.
+    ///
+    /// Returns an AnyPublisher<Bool, EosioError>.
+    public func signAndBroadcastPublisher() -> AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.signAndBroadcast(completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method for signing a transaction.
+    ///
+    /// Returns AnyPublisher<Bool, EosioError>.
+    public func signPublisher() -> AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.sign(completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method for signing a transaction with available keys.
+    ///
+    /// - Parameters:
+    ///   - availableKeys: An array of public key strings that correspond to the private keys availble for signing.
+    ///
+    /// Returns AnyPublisher<Bool, EosioError>.
+    public func signPublisher(availableKeys: [String]) -> AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.sign(availableKeys: availableKeys, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method for signing a transaction with publicKeys keys.
+    ///
+    /// - Parameters:
+    ///   - publicKeys: An array of public key strings that correspond to the private keys to sign the transaction with.
+    ///
+    /// Returns AnyPublisher<Bool, EosioError>.
+    public func signPublisher(publicKeys: [String]) -> AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.sign(publicKeys: publicKeys, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method for broadcast a transaction.
+    ///
+    /// Returns Promise<Bool>.
+    public func broadcastPublisher() -> AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.broadcast(completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method to serialize a transaction.
+    ///
+    /// Returns AnyPublisher<Data, EosioError>.
+    public func serializeTransactionPublisher() -> AnyPublisher<Data, EosioError> {
+        return Future<Data, EosioError> { [weak self] promise in
+            self?.serializeTransaction(completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+
+    /// Publisher based method to prepare a transaction.
+    ///
+    /// Returns AnyPublisher<Bool, EosioError>.
+    public func preparePublisher() ->AnyPublisher<Bool, EosioError> {
+        return Future<Bool, EosioError> { [weak self] promise in
+            self?.prepare(completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
+}

--- a/EosioSwift/Foundation/EosioResult.swift
+++ b/EosioSwift/Foundation/EosioResult.swift
@@ -27,4 +27,13 @@ public enum EosioResult<Success, Failure: Error> {
             return nil
         }
     }
+
+    var asResult: Result<Success, Failure> {
+        switch self {
+        case .success(let result):
+            return .success(result)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
 }


### PR DESCRIPTION
If using iOS 13+ now you can receive a combine publisher in addition to closures and PromiseKit for functionality on rpc provider and transaction.