### PR TITLE
Add get_kv_table_rows support.  Add EXAMPLES.md file.

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,243 @@
+# EOSIO SDK for Swift Examples
+
+EOSIO SDK for Swift contains an exenstive set of functionality beyond the basics required for transactions.  The code snippets below show how to use some of this extended functionality.  It is important to note that these are simply example snippets and may not work the way you expect if you just copy and paste them into a method.  One common mistake is to allow the transaction or one of the providers to go out of scope, resulting in an error in the return closure when the server replies to the transaction request.  If you are seeing "self does not exist" errors when trying to send transactions or RPC calls, check to make sure that your objects are being held properly.
+
+## Basic Transaction Examples
+
+### Submiting a Transaction
+
+Basic submission of a transaction is shown in the main [README.md](README.md) file at the top level of the repository.  Please see the [Basic Usage](README.md/#basic-usage) example for details.
+
+### How to Transfer an EOSIO Token
+
+The [Basic Usage](README.md/#basic-usage) example in the top level [README.md](README.md) file is an example of transferring an EOSIO token.  Please see that example for details.
+
+## Extended Transaction Examples
+
+### Retrieving Action Return Values From Transactions
+
+This snippets calls a transaction that returns a 32-bit integer value.  The user is required to know the correct type that the action returns in order to cast successfully.  Each action will contain its return value, if the server provided one.
+
+```
+let url = URL(string: "https://my.example.blockchain")!
+rpcProvider = EosioRpcProvider(endpoint: url)
+transaction.rpcProvider = rpcProvider
+transaction.serializationProvider = EosioAbieosSerializationProvider()
+transaction.signatureProvider = try EosioSoftkeySignatureProvider(privateKeys: ["YourPrivateKey"])
+
+let action = try EosioTransaction.Action(
+    account: EosioName("returnvalue"),
+    name: EosioName("actionresret"),
+    authorization: [EosioTransaction.Action.Authorization(
+        actor: EosioName("bob"),
+        permission: EosioName("active"))
+    ],
+    data: [String: Any]()
+)
+transaction.add(action: action)
+
+transaction.signAndBroadcast { result in
+    switch result {
+    case .success:
+        print("Transaction successful, action return value is: \(String(describing: action.returnValue))")
+        let returnValue = action.returnValue as? Int32
+    case .failure(let error):
+        print("Transaction failed, error: \(error)")
+    }
+}
+```
+
+### Accessing Extended Fields in Transaction Responses
+
+Using `EosioTransaction.signAndBroadcast()` provides an easy way to sign and submit transactions but has a limited amount of information that it returns.  If you need to get additional information back from the blockchain, you must use `sendTransactionBase()` from [`EosioRpcProvider`](Sources/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift) to submit the transaction after it is signed.  The process is much the same as a normal flow but instead of calling `signAndBroadcast()`,  use `sign()` instead and load the results into a `EosioRpcSendTransactionRequest` to be sent to the blockchain.  Afterward, the full response is available and can be decoded.  A small subset of fields are shown in the example below.  
+
+```
+transaction = EosioTransaction()
+let url = URL(string: "https://my.test.blockchain")!
+rpcProvider = EosioRpcProvider(endpoint: url)
+transaction.rpcProvider = rpcProvider
+transaction.serializationProvider = EosioAbieosSerializationProvider()
+
+do {
+    transaction.signatureProvider = try EosioSoftkeySignatureProvider(privateKeys: ["MyTestKey"])
+    let action = try EosioTransaction.Action(
+        account: EosioName("eosio.token"),
+        name: EosioName("transfer"),
+        authorization: [EosioTransaction.Action.Authorization(
+                            actor: EosioName("bob"),
+                            permission: EosioName("active"))
+        ],
+        data: Transfer(from: EosioName("bob"),
+                       to: EosioName("alice"),
+                       quantity: "42.0000 SYS",
+                       memo: "This is only a test")
+    )
+    transaction.add(action: action)
+    
+
+    transaction.sign { result in
+        switch result {
+        case .success:
+            guard let serializedTransaction = self.transaction.serializedTransaction?.hexEncodedString(),
+                  let signatures = self.transaction.signatures else {
+                print("Error, could not find signatures or serialized transaction.")
+                return
+            }
+            
+            let requestParameters = EosioRpcSendTransactionRequest(signatures: signatures,
+                                                                   compression: 0,
+                                                                   packedContextFreeData: "",
+                                                                   packedTrx: serializedTransaction)
+            
+            self.rpcProvider.sendTransactionBase(requestParameters: requestParameters) { response in
+                switch response {
+                case .success(let sentResponse):
+                    let transactionId = sentResponse.transactionId
+                    if let sentTransactionResponse = sentResponse as? EosioRpcTransactionResponse {
+                        if let processed = sentTransactionResponse.processed as [String: Any]?,
+                           let receipt = processed["receipt"] as? [String: Any],
+                           let status = receipt["status"] as? String {
+                            // Work with values
+                        } else {
+                            print("Should be able to find processed.receipt.status.")
+                        }
+                    } else {
+                        print("Concrete response type should be EosioRpcTransactionResponse.")
+                    }
+                case .failure(let err):
+                    print("\(err.description)")
+                }
+            }
+        case .failure(let error):
+            print("Transaction failed, error: \(error)")
+        }
+    }
+    
+} catch (let error) {
+    print("Handle this error: \(error.localizedDescription)")
+}
+```
+
+## Extended RPC Call Examples
+
+### Get Account Information
+
+This snippet retrieves information for an account on the blockchain.  There are several layers of response to unpack if all information is desired.  Some portions of the response are not fully unmarshalled, either due to size or because the responses can vary in structure.  These are returned as general `[String: Any]` Swift objects.  The [NODEOS Reference](https://developers.eos.io/eosio-nodeos/reference) is helpful for decoding the parts of responses that are not fully unmarshalled.  
+
+```
+let url = URL(string: "https://my.example.blockchain")!
+rpcProvider = EosioRpcProvider(endpoint: url)
+
+let requestParameters = EosioRpcAccountRequest(accountName: "cryptkeeper")
+rpcProvider.getAccount(requestParameters: requestParameters) { response in
+    switch response {
+    case .success(let eosioRpcAccountResponse):
+        guard let response = eosioRpcAccountResponse else { 
+            // Handle condition
+            return 
+        }
+        let accountname = response.accountName
+        let ramQuota = response.ramQuota.value
+    
+        guard let permissions = response.permissions else {
+            // Handle Condition
+            return
+        }
+        guard let activePermission = permissions.filter({$0.permName == "active"}).first else {
+            print("Cannot find Active permission in permissions structure of the account")
+            return
+        }
+        guard activePermission.parent == "owner" else {
+            print("Active Key does not have proper parent.")
+            return
+        }
+        guard let keysAndWeight = activePermission.requiredAuth.keys.first else {
+            print("Cannot find key in keys structure of the account")
+            return
+        }
+        let key = keysAndWeight.key
+        guard let firstPermission = activePermission.requiredAuth.accounts.first else {
+            print("Can't find permission in keys structure of the account")
+            return
+        }
+        let actor = firstPermission.permission.actor
+        let permission = firstPermission.permission.permission
+        let waitSec = activePermission.requiredAuth.waits.first?.waitSec.value
+        guard let dict = eosioRpcAccountResponse.totalResources as? [String: Any] else {
+            print("Could not find total resources as [String: Any].")
+            return
+        }
+        let owner = dict["owner"] as? String
+        let rambytes = dict["ram_bytes"] as? UInt64
+
+    case .failure(let err):
+        print(err.description)
+        XCTFail("Failed get_account")
+    }
+    expect.fulfill()
+}
+```
+
+### Getting Transaction Information From the History Plugin
+
+This snippet returns information on a transaction from the History API plugin.  Only a few fields are shown in the decoding example below.  The [NODEOS Reference](https://developers.eos.io/eosio-nodeos/reference) is helpful for decoding the parts of responses that are not fully unmarshalled.  
+
+```
+let url = URL(string: "https://my.test.blockchain")!
+rpcProvider = EosioRpcProvider(endpoint: url)
+
+let requestParameters = EosioRpcHistoryTransactionRequest(transactionId: "ae735820e26a7b771e1b522186294d7cbba035d0c31ca88237559d6c0a3bf00a", blockNumHint: 21098575)
+rpcProvider.getTransaction(requestParameters: requestParameters) { response in
+    switch response {
+    case .success(let eosioRpcGetTransactionResponse):
+        let returnedId = eosioRpcGetTransactionResponse.id
+        let returnedBlockNum = eosioRpcGetTransactionResponse.blockNum.value
+        guard let dict = eosioRpcGetTransactionResponse.trx["trx"] as? [String: Any] else {
+            print("Should find trx.trx dictionary.")
+            return
+        }
+        if let refBlockNum = dict["ref_block_num"] as? UInt64 {
+            print(refBlockNum)
+        } else {
+            XCTFail("Should find trx ref_block_num.")
+        }
+        if let signatures = dict["signatures"] as? [String] {
+            print(signatures[0])
+        } else {
+            print("Should find trx signatures and it should match.")
+        }
+    case .failure(let err):
+        print("Failed get_transaction call: \(err.description)")
+    }
+}
+```
+
+### Retrieving Values from KV Tables
+
+This snippet retrieves values from a KV table defined by a contract on the server.  The example below is requesting the values from the contract "todo" in the table named "todo".  It is querying the index named "uuid" for the value "bf581bee-9f2c-447b-94ad-78e4984b6f51".  The encoding type of the indexValue being supplied is ".string".  Other supported encoding types can be found in the full documenation in this repo at  `docs/EosioSwift/index.html`.
+
+```
+let url = URL(string: "https://my.example.blockchain")!
+rpcProvider = EosioRpcProvider(endpoint: url)
+
+let tablesRequest = EosioRpcKvTableRowsRequest(code: "todo",
+                                               table: "todo",
+                                               indexName: "uuid",
+                                               encodeType: .string,
+                                               json: true,
+                                               indexValue: "bf581bee-9f2c-447b-94ad-78e4984b6f51")
+
+rpcProvider.getKvTableRows(requestParameters: tablesRequest) { result in
+    switch result {
+    case .failure(let error):
+        print("Failed getKvTableRows call: \(error.localizedDescription)")
+    case .success(let response):
+        // Iterate through rows.  They will either be serialied strings if json equaled false
+        // or they will be [String: Any] representations of the returned JSON objects if 
+        // json equaled true in the request.
+        response.rows.foreach { row in
+            // Work with each row.
+        }
+    }
+}
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,6 +2,8 @@
 
 EOSIO SDK for Swift contains an extensive set of functionality beyond the basics required for transactions.  The code snippets below show how to use some of this extended functionality.  It is important to note that these are simply example snippets and may not work the way you expect if you just copy and paste them into a method.  One common mistake is to allow the transaction or one of the providers to go out of scope, resulting in an error in the return closure when the server replies to the transaction request.  If you are seeing "self does not exist" errors when trying to send transactions or RPC calls, check to make sure that your objects are being held properly.
 
+Note: For clarity, these examples use the soft key signature provider which is NOT recommended for production use!
+
 ## Basic Transaction Examples
 
 ### Submitting a Transaction
@@ -16,9 +18,9 @@ The [Basic Usage](README.md/#basic-usage) example in the top level [README.md](R
 
 ### Retrieving Action Return Values From Transactions
 
-This snippets calls a transaction that returns a 32-bit integer value.  The user is required to know the correct type that the action returns in order to cast successfully.  Each action will contain its return value, if the server provided one.
+This snippet calls a transaction that returns a 32-bit integer value.  The user is required to know the correct type that the action returns in order to cast successfully.  Each action will contain its return value, if the server provided one.
 
-```
+```swift
 let url = URL(string: "https://my.example.blockchain")!
 rpcProvider = EosioRpcProvider(endpoint: url)
 transaction.rpcProvider = rpcProvider
@@ -51,7 +53,7 @@ transaction.signAndBroadcast { result in
 
 Using `EosioTransaction.signAndBroadcast()` provides an easy way to sign and submit transactions but has a limited amount of information that it returns.  If you need to get additional information back from the blockchain, you must use `sendTransactionBase()` from [`EosioRpcProvider`](Sources/EosioSwift/EosioRpcProvider/EosioRpcProvider.swift) to submit the transaction after it is signed.  The process is much the same as a normal flow but instead of calling `signAndBroadcast()`,  use `sign()` instead and load the results into a `EosioRpcSendTransactionRequest` to be sent to the blockchain.  Afterward, the full response is available and can be decoded.  A small subset of fields are shown in the example below.  
 
-```
+```swift
 transaction = EosioTransaction()
 let url = URL(string: "https://my.test.blockchain")!
 rpcProvider = EosioRpcProvider(endpoint: url)
@@ -124,7 +126,7 @@ do {
 
 This snippet retrieves information for an account on the blockchain.  There are several layers of response to unpack if all information is desired.  Some portions of the response are not fully unmarshalled, either due to size or because the responses can vary in structure.  These are returned as general `[String: Any]` Swift objects.  The [NODEOS Reference](https://developers.eos.io/eosio-nodeos/reference) is helpful for decoding the parts of responses that are not fully unmarshalled.  
 
-```
+```swift
 let url = URL(string: "https://my.example.blockchain")!
 rpcProvider = EosioRpcProvider(endpoint: url)
 
@@ -182,7 +184,7 @@ rpcProvider.getAccount(requestParameters: requestParameters) { response in
 
 This snippet returns information on a transaction from the History API plugin.  Only a few fields are shown in the decoding example below.  The [NODEOS Reference](https://developers.eos.io/eosio-nodeos/reference) is helpful for decoding the parts of responses that are not fully unmarshalled.  
 
-```
+```swift
 let url = URL(string: "https://my.test.blockchain")!
 rpcProvider = EosioRpcProvider(endpoint: url)
 
@@ -216,7 +218,7 @@ rpcProvider.getTransaction(requestParameters: requestParameters) { response in
 
 This snippet retrieves values from a KV table defined by a contract on the server.  The example below is requesting the values from the contract "todo" in the table named "todo".  It is querying the index named "uuid" for the value "bf581bee-9f2c-447b-94ad-78e4984b6f51".  The encoding type of the indexValue being supplied is ".string".  Other supported encoding types can be found in the full documenation in this repo at  `docs/EosioSwift/index.html`.
 
-```
+```swift
 let url = URL(string: "https://my.example.blockchain")!
 rpcProvider = EosioRpcProvider(endpoint: url)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4,7 +4,7 @@ EOSIO SDK for Swift contains an extensive set of functionality beyond the basics
 
 ## Basic Transaction Examples
 
-### Submiting a Transaction
+### Submitting a Transaction
 
 Basic submission of a transaction is shown in the main [README.md](README.md) file at the top level of the repository.  Please see the [Basic Usage](README.md/#basic-usage) example for details.
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,6 +1,6 @@
 # EOSIO SDK for Swift Examples
 
-EOSIO SDK for Swift contains an exenstive set of functionality beyond the basics required for transactions.  The code snippets below show how to use some of this extended functionality.  It is important to note that these are simply example snippets and may not work the way you expect if you just copy and paste them into a method.  One common mistake is to allow the transaction or one of the providers to go out of scope, resulting in an error in the return closure when the server replies to the transaction request.  If you are seeing "self does not exist" errors when trying to send transactions or RPC calls, check to make sure that your objects are being held properly.
+EOSIO SDK for Swift contains an extensive set of functionality beyond the basics required for transactions.  The code snippets below show how to use some of this extended functionality.  It is important to note that these are simply example snippets and may not work the way you expect if you just copy and paste them into a method.  One common mistake is to allow the transaction or one of the providers to go out of scope, resulting in an error in the return closure when the server replies to the transaction request.  If you are seeing "self does not exist" errors when trying to send transactions or RPC calls, check to make sure that your objects are being held properly.
 
 ## Basic Transaction Examples
 

--- a/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCallbacks.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCallbacks.swift
@@ -207,6 +207,17 @@ extension EosioRpcProvider {
             completion(EosioResult(success: result, failure: error)!)
         }
     }
+    
+    /// Call `chain/get_kv_table_rows`. Returns an object containing rows from the specified table.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcKvTableRowsRequest`.
+    ///   - completion: Called with the response, as an `EosioResult` consisting of an `EosioRpcKvTableRowsResponse` and an optional `EosioError`.
+    public func getKvTableRows(requestParameters: EosioRpcKvTableRowsRequest, completion:@escaping (EosioResult<EosioRpcKvTableRowsResponse, EosioError>) -> Void) {
+        getResource(rpc: "chain/get_kv_table_rows", requestParameters: requestParameters) {(result: EosioRpcKvTableRowsResponse?, error: EosioError?) in
+            completion(EosioResult(success: result, failure: error)!)
+        }
+    }
 
     /// Call `chain/get_code`.
     ///

--- a/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCombine.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsCombine.swift
@@ -209,6 +209,17 @@ extension EosioRpcProvider {
             self?.getTableRows(requestParameters: requestParameters, completion: { promise($0.asResult) })
         }.eraseToAnyPublisher()
     }
+    
+    /// Call `chain/get_kv_table_rows` and get a Publisher back. Returns an object containing rows from the specified table.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcKvTableRowsRequest`.
+    /// - Returns: A Publisher fulfilled with an `EosioRpcKvTableRowsResponse` or rejected with an `EosioError`.
+    public func getKvTableRowsPublisher(requestParameters: EosioRpcKvTableRowsRequest) -> AnyPublisher<EosioRpcKvTableRowsResponse, EosioError> {
+        return Future<EosioRpcKvTableRowsResponse, EosioError> { [weak self] promise in
+            self?.getKvTableRows(requestParameters: requestParameters, completion: { promise($0.asResult) })
+        }.eraseToAnyPublisher()
+    }
 
     /// Call `chain/get_code` and get a Publisher back.
     ///

--- a/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsPromises.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsPromises.swift
@@ -192,6 +192,16 @@ extension EosioRpcProvider {
         return Promise { getTableRows(requestParameters: requestParameters, completion: $0.resolve) }
     }
 
+    /// Call `chain/get_kv_table_rows` and get a Promise back. Returns an object containing rows from the specified table.
+    ///
+    /// - Parameters:
+    ///   - _: Differentiates call signature from that of non-promise-returning endpoint method. Pass in `.promise` as the first parameter to call this method.
+    ///   - requestParameters: An `EosioRpcKvTableRowsRequest`.
+    /// - Returns: A Promise fulfilled with an `EosioRpcKvTableRowsResponse` or rejected with an `EosioError`.
+    public func getKvTableRows(_: PMKNamespacer, requestParameters: EosioRpcKvTableRowsRequest) -> Promise<EosioRpcKvTableRowsResponse> {
+        return Promise { getKvTableRows(requestParameters: requestParameters, completion: $0.resolve) }
+    }
+    
     /// Call `chain/get_code` and get a Promise back.
     ///
     /// - Parameters:

--- a/Sources/EosioSwift/EosioRpcProvider/Models/RpcProviderRequestModels.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Models/RpcProviderRequestModels.swift
@@ -177,6 +177,80 @@ public struct EosioRpcTableRowsRequest: Codable {
     }
 }
 
+/// The request type for `get_kv_table_rows` RPC requests.
+public struct EosioRpcKvTableRowsRequest: Codable {
+    /// Encoding types for `indexValue`, `lowerBound` or `upperBound`
+    public enum EncodeType: String, Codable {
+        /// Arbitrary binary index values.
+        case bytes
+        /// String encoding
+        case string
+        /// Decimal encoding
+        case dec
+        /// Hexidecimal encoding
+        case hex
+        /// EosioName encoding
+        case name
+    }
+    /// The name of the smart contract that controls the provided kv table.
+    public var code: String
+    /// The name of the kv table to query.
+    public var table: String
+    ///The name of the primary or secondary index.
+    public var indexName: String
+    /// The type of key specified by by the `indexName`.  This can be `bytes` for arbitrary binary index values or C++ types such as `uint64_t` or `name` for `EosioName` values.
+    public var encodeType: EncodeType
+    /// Should the results be deserialized and returned as json.
+    public var json: Bool
+    /// The value used for an exact match query, encoded as the specified `encodeType`.
+    public var indexValue: String?
+    /// The lower bound value for a ranged query, encoded as the specified `encodeType`.  Not used if `indexValue` is specified.  Optional if `reverse` is `true`.
+    public var lowerBound: String?
+    /// The upper bound value for a ranged query, encoded as the specified `encodeType`.  Not used if `indexValue is specified`.  Optional if `reverse` is `false`.
+    public var upperBound: String?
+    /// Limit number of results returned.
+    public var limit: Int32
+    /// Reverse the order of returned results.
+    public var reverse: Bool?
+    
+    public init(
+        code: String,
+        table: String,
+        indexName: String,
+        encodeType: EncodeType = .bytes,
+        json: Bool = true,
+        indexValue: String? = nil,
+        lowerBound: String? = nil,
+        upperBound: String? = nil,
+        limit: Int32 = 10,
+        reverse: Bool? = nil
+    ) {
+        self.code = code
+        self.table = table
+        self.indexName = indexName
+        self.encodeType = encodeType
+        self.json = json
+        self.indexValue = indexValue
+        self.lowerBound = lowerBound
+        self.upperBound = upperBound
+        self.limit = limit
+        self.reverse = reverse
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case code
+        case table
+        case indexName = "index_name"
+        case encodeType = "encode_type"
+        case json
+        case indexValue = "index_value"
+        case lowerBound = "lower_bound"
+        case upperBound = "upper_bound"
+        case limit
+        case reverse
+    }
+}
+
 /// The request type for `get_code` RPC requests.
 public struct EosioRpcCodeRequest: Codable {
     public var accountName: String

--- a/Sources/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Models/RpcProviderResponseModels.swift
@@ -1075,6 +1075,28 @@ public struct EosioRpcTableRowsResponse: Decodable, EosioRpcResponseProtocol {
     }
 }
 
+/// Response type for the `get_kv_table_rows` RPC endpoint.
+public struct EosioRpcKvTableRowsResponse: Decodable, EosioRpcResponseProtocol {
+    public var _rawResponse: Any?
+    public var rows: [Any] = [Any]()
+    public var more: Bool
+    public var nextKey: String
+    
+    enum CustomCodingKeys: String, CodingKey {
+        case rows
+        case more
+        case nextKey = "next_key"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CustomCodingKeys.self)
+        var rowsContainer = try? container.nestedUnkeyedContainer(forKey: .rows)
+        rows = rowsContainer?.decodeDynamicValues() ?? [Any]()
+        more = try container.decodeIfPresent(Bool.self, forKey: .more) ?? false
+        nextKey = try container.decodeIfPresent(String.self, forKey: .nextKey) ?? ""
+    }
+}
+
 /// Response struct for the rows returned from get_table_by_scope
 public struct TableByScopeRows: Decodable {
     public var code: String

--- a/Tests/EosioSwiftIntegrationTests/ActionReturnTests.swift
+++ b/Tests/EosioSwiftIntegrationTests/ActionReturnTests.swift
@@ -28,7 +28,7 @@ class ActionReturnTests: XCTestCase {
     override func setUpWithError() throws {
         /*
         transaction = EosioTransaction()
-        let url = URL(string: "http://10.0.0.112:8888")!
+        let url = URL(string: "https://my.test.blockchain")!
         rpcProvider = EosioRpcProvider(endpoint: url)
         transaction.rpcProvider = rpcProvider
         transaction.serializationProvider = EosioAbieosSerializationProvider()
@@ -108,5 +108,5 @@ class ActionReturnTests: XCTestCase {
         wait(for: [expect], timeout: 30)
         
     }
-    
+
 }

--- a/Tests/EosioSwiftIntegrationTests/ActionReturnTests.swift
+++ b/Tests/EosioSwiftIntegrationTests/ActionReturnTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ActionReturnTests.swift
 //  
 //
 //  Created by Steve McCoole on 9/25/20.

--- a/Tests/EosioSwiftIntegrationTests/GetKvTableRowsTests.swift
+++ b/Tests/EosioSwiftIntegrationTests/GetKvTableRowsTests.swift
@@ -1,0 +1,66 @@
+//
+//  GetKvTableRowsTests.swift
+//  
+//
+//  Created by Steve McCoole on 11/2/20.
+//
+
+import XCTest
+@testable import EosioSwiftAbieosSerializationProvider
+@testable import EosioSwift
+@testable import EosioSwiftSoftkeySignatureProvider
+
+class GetKvTableRowsTests: XCTestCase {
+    var transaction = EosioTransaction()
+    var rpcProvider: EosioRpcProvider!
+    
+    struct Transfer: Codable {
+        var from: EosioName
+        var to: EosioName // swiftlint:disable:this identifier_name
+        var quantity: String
+        var memo: String
+    }
+    
+    override func setUpWithError() throws {
+
+        transaction = EosioTransaction()
+        let url = URL(string: "https://8000-a67a1a17-5713-42b5-ba3e-ea1654012dd6.ws-us02.gitpod.io")!
+        rpcProvider = EosioRpcProvider(endpoint: url)
+        transaction.rpcProvider = rpcProvider
+        transaction.serializationProvider = EosioAbieosSerializationProvider()
+        transaction.signatureProvider = try EosioSoftkeySignatureProvider(privateKeys: ["5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"])
+         
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testGetKvTableRows() throws {
+        let tablesRequest = EosioRpcKvTableRowsRequest(code: "todo",
+                                                       table: "todo",
+                                                       indexName: "uuid",
+                                                       encodeType: .string,
+                                                       json: true,
+                                                       indexValue: "bf581bee-9f2c-447b-94ad-78e4984b6f51")
+        
+        let expect = expectation(description: "testGetKvTableRows")
+        
+        rpcProvider.getKvTableRows(requestParameters: tablesRequest) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Should not fail getKvTableRows call: \(error.localizedDescription)")
+            case .success(let response):
+                let rows = response.rows
+                XCTAssertNotNil(rows)
+                XCTAssert(rows.count > 0)
+                print ("Rows returned: \(rows)")
+                expect.fulfill()
+            }
+        }
+        
+        wait(for: [expect], timeout: 30)
+    }
+    
+}
+

--- a/Tests/EosioSwiftIntegrationTests/GetKvTableRowsTests.swift
+++ b/Tests/EosioSwiftIntegrationTests/GetKvTableRowsTests.swift
@@ -23,12 +23,14 @@ class GetKvTableRowsTests: XCTestCase {
     
     override func setUpWithError() throws {
 
+        /*
         transaction = EosioTransaction()
-        let url = URL(string: "https://8000-a67a1a17-5713-42b5-ba3e-ea1654012dd6.ws-us02.gitpod.io")!
+        let url = URL(string: "https://my.test.blockchain")!
         rpcProvider = EosioRpcProvider(endpoint: url)
         transaction.rpcProvider = rpcProvider
         transaction.serializationProvider = EosioAbieosSerializationProvider()
         transaction.signatureProvider = try EosioSoftkeySignatureProvider(privateKeys: ["5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"])
+        */
          
     }
 
@@ -36,7 +38,7 @@ class GetKvTableRowsTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
-    func testGetKvTableRows() throws {
+    func skip_testGetKvTableRows() throws {
         let tablesRequest = EosioRpcKvTableRowsRequest(code: "todo",
                                                        table: "todo",
                                                        indexName: "uuid",
@@ -54,7 +56,9 @@ class GetKvTableRowsTests: XCTestCase {
                 let rows = response.rows
                 XCTAssertNotNil(rows)
                 XCTAssert(rows.count > 0)
-                print ("Rows returned: \(rows)")
+                response.rows.forEach { row in
+                    print("row: \(row)")
+                }
                 expect.fulfill()
             }
         }


### PR DESCRIPTION
Cannot fully test get_kv_table_rows yet as the docker image builds are still broken.  It did return the serialized form just fine though.

Added the EXAMPLES.md file.  Intended to be more advanced snippets to help with extended SDK use but did not want to crowd up the README.md file with them.  Initial set suggested by @brandonfancher 