### PR TITLE
Create index file for docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+## Code Documentation
+
+The EOSIO SDK for Swift repo consists of four modules. You can access the generated code documentation for each as follows:
+
+* [Core Library](https://eosio.github.io/eosio-swift/EosioSwift/) (`EosioSwift`)
+* [ABIEOS Serialization Provider](https://eosio.github.io/eosio-swift/EosioSwiftAbieosSerializationProvider/) (`EosioSwiftAbieosSerializationProvder`)
+* [ECC](https://eosio.github.io/eosio-swift/EosioSwiftEcc/) (`EosioSwiftEcc`)
+* [Softkey Signature Provider](https://eosio.github.io/eosio-swift/EosioSwiftSoftkeySignatureProvider/) (`EosioSwiftSoftkeySignatureProvider`)


### PR DESCRIPTION
Now that we have subdirectories in the `/docs` directory, we need an index for our docs link.