### PR TITLE
Support for old nodes

### DIFF
--- a/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsForProtocol.swift
+++ b/Sources/EosioSwift/EosioRpcProvider/Endpoints/EosioRpcProviderEndpointsForProtocol.swift
@@ -30,6 +30,17 @@ extension EosioRpcProvider: EosioRpcProviderProtocol {
             completion(EosioResult(success: result, failure: error)!)
         }
     }
+    
+    /// Call `chain/get_block`. This method is called by `EosioTransaction`, as it only enforces the response protocol, not the entire response struct.
+    ///
+    /// - Parameters:
+    ///   - requestParameters: An `EosioRpcBlockRequest`.
+    ///   - completion: Called with the response, as an `EosioResult` consisting of a response conforming to `EosioRpcBlockResponseProtocol` and an optional `EosioError`.
+    public func getBlockBase(requestParameters: EosioRpcBlockRequest, completion: @escaping (EosioResult<EosioRpcBlockResponse, EosioError>) -> Void) {
+        getResource(rpc: "chain/get_block", requestParameters: requestParameters) {(result: EosioRpcBlockResponse?, error: EosioError?) in
+            completion(EosioResult(success: result, failure: error)!)
+        }
+    }
 
     /// Call `chain/get_raw_abi`. This method is called by `EosioTransaction`, as it only enforces the response protocol, not the entire response struct.
     ///

--- a/Sources/EosioSwift/EosioRpcProviderProtocol/EosioRpcProviderProtocol.swift
+++ b/Sources/EosioSwift/EosioRpcProviderProtocol/EosioRpcProviderProtocol.swift
@@ -34,6 +34,12 @@ public protocol EosioRpcProviderProtocol {
     /// - Parameter completion: Completion called with an `EosioResult`.
     func getBlockInfoBase(requestParameters: EosioRpcBlockInfoRequest, completion: @escaping(EosioResult<EosioRpcBlockInfoResponseProtocol, EosioError>) -> Void)
 
+    /// Calls /v1/chain/get_block.
+    ///
+    /// - Parameter completion: Completion called with an `EosioResult`.
+    @available(*, deprecated, message: "Use `getBlockInfoBase` instead, getBlockBase remains here to support old nodes")
+    func getBlockBase(requestParameters: EosioRpcBlockRequest, completion: @escaping (EosioResult<EosioRpcBlockResponse, EosioError>) -> Void)
+    
     /// Calls /v1/chain/get_raw_abi.
     ///
     /// - Parameter completion: Completion called with an `EosioResult`.

--- a/Sources/EosioSwift/EosioTransaction/EosioTransactionFactory.swift
+++ b/Sources/EosioSwift/EosioTransaction/EosioTransactionFactory.swift
@@ -10,7 +10,6 @@ import Foundation
 
 /// Convenience class for creating transactions on EOSIO-based blockchains. Once you set properties (`rpcProvider` etc.), you don't have to set them again in order to create a new transaction.
 public class EosioTransactionFactory {
-
     /// Remote Procedure Call (RPC) provider for facilitating communication with blockchain nodes. Conforms to `EosioRpcProviderProtocol`.
     let rpcProvider: EosioRpcProviderProtocol
     /// Signature provider for facilitating the retrieval of available public keys and the signing of transactions. Conforms to `EosioSignatureProviderProtocol`.
@@ -21,6 +20,8 @@ public class EosioTransactionFactory {
     let abiProvider: EosioAbiProviderProtocol?
     /// Transaction configuration.
     let config: EosioTransaction.Config?
+    
+    let chainVersion: EosioTransaction.ChainVersion
 
     /// Initializes the class.
     public init(
@@ -28,13 +29,15 @@ public class EosioTransactionFactory {
         signatureProvider: EosioSignatureProviderProtocol,
         serializationProvider: EosioSerializationProviderProtocol,
         abiProvider: EosioAbiProviderProtocol? = nil,
-        config: EosioTransaction.Config? = nil
+        config: EosioTransaction.Config? = nil,
+        chainVersionSupport: EosioTransaction.ChainVersion = .v2
     ) {
         self.rpcProvider = rpcProvider
         self.signatureProvider = signatureProvider
         self.serializationProvider = serializationProvider
         self.abiProvider = abiProvider
         self.config = config
+        self.chainVersion = chainVersionSupport
     }
 
     /// Returns a new `EosioTransaction` instance.
@@ -45,6 +48,7 @@ public class EosioTransactionFactory {
         newTransaction.signatureProvider = signatureProvider
         newTransaction.serializationProvider = serializationProvider
         newTransaction.abiProvider = abiProvider
+        newTransaction.chainVersion = chainVersion
         if let config = config { newTransaction.config = config }
 
         return newTransaction


### PR DESCRIPTION
Tackling issue: https://github.com/EOSIO/eosio-swift/issues/295

Usage: 

```swift
self.transactionFactory = EosioTransactionFactory(rpcProvider: rpcProvider,
                                                          signatureProvider: signatureProvider,
                                                          serializationProvider: serializationProvider,
                                                          chainVersionSupport: .v2)
```